### PR TITLE
feat: propose a simpler way to get software row_id

### DIFF
--- a/evadb/readers/pdf_reader.py
+++ b/evadb/readers/pdf_reader.py
@@ -35,11 +35,10 @@ class PDFReader(AbstractReader):
 
         # PAGE ID, PARAGRAPH ID, STRING
         # Maintain a global paragraph number per PDF
-        global_paragraph_no = 0
         for page_no, page in enumerate(doc):
             blocks = page.get_text("dict")["blocks"]
             # iterate through the text blocks
-            for _, b in enumerate(blocks):
+            for paragraph_no, b in enumerate(blocks):
                 # this block contains text
                 if b["type"] == 0:
                     # text found in block
@@ -52,8 +51,7 @@ class PDFReader(AbstractReader):
                             if span["text"].strip():
                                 block_string += span["text"]
                     yield {
-                        "paragraph": global_paragraph_no,
+                        "paragraph": paragraph_no,
                         "page": page_no,
                         "data": block_string,
                     }
-                    global_paragraph_no += 1

--- a/evadb/storage/document_storage_engine.py
+++ b/evadb/storage/document_storage_engine.py
@@ -29,8 +29,10 @@ class DocumentStorageEngine(AbstractMediaStorageEngine):
     def read(
         self, table: TableCatalogEntry, chunk_params: dict = {}
     ) -> Iterator[Batch]:
+        # Software row_id generated at runtime
+        row_id = 1
         for doc_files in self._rdb_handler.read(self._get_metadata_table(table), 12):
-            for _, (row_id, file_name) in doc_files.iterrows():
+            for _, (_, file_name) in doc_files.iterrows():
                 system_file_name = self._xform_file_url_to_file_name(file_name)
                 doc_file = Path(table.file_url) / system_file_name
                 # setting batch_mem_size = 1, we need fix it
@@ -41,3 +43,4 @@ class DocumentStorageEngine(AbstractMediaStorageEngine):
                     batch.frames[table.columns[0].name] = row_id
                     batch.frames[table.columns[1].name] = str(file_name)
                     yield batch
+                    row_id += 1

--- a/evadb/storage/image_storage_engine.py
+++ b/evadb/storage/image_storage_engine.py
@@ -27,8 +27,10 @@ class ImageStorageEngine(AbstractMediaStorageEngine):
         super().__init__(db)
 
     def read(self, table: TableCatalogEntry) -> Iterator[Batch]:
+        # Software row_id generated at runtime
+        row_id = 1
         for image_files in self._rdb_handler.read(self._get_metadata_table(table), 12):
-            for _, (row_id, file_name) in image_files.iterrows():
+            for _, (_, file_name) in image_files.iterrows():
                 system_file_name = self._xform_file_url_to_file_name(file_name)
                 image_file = Path(table.file_url) / system_file_name
                 # setting batch_mem_size = 1, we need fix it
@@ -37,3 +39,4 @@ class ImageStorageEngine(AbstractMediaStorageEngine):
                     batch.frames[table.columns[0].name] = row_id
                     batch.frames[table.columns[1].name] = str(file_name)
                     yield batch
+                    row_id += 1

--- a/evadb/storage/pdf_storage_engine.py
+++ b/evadb/storage/pdf_storage_engine.py
@@ -27,8 +27,10 @@ class PDFStorageEngine(AbstractMediaStorageEngine):
         super().__init__(db)
 
     def read(self, table: TableCatalogEntry) -> Iterator[Batch]:
+        # Software row_id generated at runtime
+        row_id = 1
         for image_files in self._rdb_handler.read(self._get_metadata_table(table), 12):
-            for _, (row_id, file_name) in image_files.iterrows():
+            for _, (_, file_name) in image_files.iterrows():
                 system_file_name = self._xform_file_url_to_file_name(file_name)
                 image_file = Path(table.file_url) / system_file_name
                 # setting batch_mem_size = 1, we need fix it
@@ -37,3 +39,4 @@ class PDFStorageEngine(AbstractMediaStorageEngine):
                     batch.frames[table.columns[0].name] = row_id
                     batch.frames[table.columns[1].name] = str(file_name)
                     yield batch
+                    row_id += 1

--- a/evadb/storage/video_storage_engine.py
+++ b/evadb/storage/video_storage_engine.py
@@ -38,8 +38,10 @@ class DecordStorageEngine(AbstractMediaStorageEngine):
         read_audio: bool = False,
         read_video: bool = True,
     ) -> Iterator[Batch]:
+        # Software row_id generated at runtime
+        row_id = 1
         for video_files in self._rdb_handler.read(self._get_metadata_table(table), 12):
-            for _, (row_id, video_file_name) in video_files.iterrows():
+            for _, (_, video_file_name) in video_files.iterrows():
                 system_file_name = self._xform_file_url_to_file_name(video_file_name)
                 video_file = Path(table.file_url) / system_file_name
                 # increase batch size when reading audio so that
@@ -59,3 +61,4 @@ class DecordStorageEngine(AbstractMediaStorageEngine):
                     batch.frames[table.columns[0].name] = row_id
                     batch.frames[table.columns[1].name] = str(video_file_name)
                     yield batch
+                    row_id += 1


### PR DESCRIPTION
The current approach to get the row_id in the base branch is a bit complicated. It requires us to modify or insert an expression to derive the row_id. It is easy for create index, but it becomes problematic for index scan. Index scan is enabled during optimization. We need to take care of the row_id expression during optimization by traversing multiple operators. I think this is not very clean. 

I am thinking we can just generate runtime time row id for storage besides structure table. The assumption is for those data table, they won't be used for operations like join, etc, so it is safe to just use a runtime row id which is different from the row_id actually stored on disk. 

Implementation-wise, I think it becomes simpler that we don't need manually insert any expression. Feedback is appreciated if any major issue is overlooked. 