### PR TITLE
feat: support create table from select api

### DIFF
--- a/apps/youtube_qa/youtube_qa.py
+++ b/apps/youtube_qa/youtube_qa.py
@@ -216,9 +216,8 @@ def generate_online_video_transcript(cursor: evadb.EvaDBCursor) -> str:
 
     # extract speech texts from videos
     cursor.drop_table("youtube_video_text", if_exists=True).execute()
-    cursor.query(
-        "CREATE TABLE IF NOT EXISTS youtube_video_text AS SELECT SpeechRecognizer(audio) FROM youtube_video;"
-    ).execute()
+    speech_recognizer_rel = cursor.table("youtube_video").select("SpeechRecognizer(audio)")
+    cursor.create_table("youtube_video_text", query=speech_recognizer_rel).execute()
     print("✅ Video analysis completed.")
 
     raw_transcript_string = (

--- a/apps/youtube_qa/youtube_qa.py
+++ b/apps/youtube_qa/youtube_qa.py
@@ -216,7 +216,9 @@ def generate_online_video_transcript(cursor: evadb.EvaDBCursor) -> str:
 
     # extract speech texts from videos
     cursor.drop_table("youtube_video_text", if_exists=True).execute()
-    speech_recognizer_rel = cursor.table("youtube_video").select("SpeechRecognizer(audio)")
+    speech_recognizer_rel = cursor.table("youtube_video").select(
+        "SpeechRecognizer(audio)"
+    )
     cursor.create_table("youtube_video_text", query=speech_recognizer_rel).execute()
     print("✅ Video analysis completed.")
 

--- a/evadb/interfaces/relational/db.py
+++ b/evadb/interfaces/relational/db.py
@@ -391,7 +391,12 @@ class EvaDBCursor(object):
         return EvaDBQuery(self._evadb, stmt)
 
     def create_table(
-        self, table_name: str, if_not_exists: bool = True, columns: str = None, query: EvaDBQuery = None, **kwargs
+        self,
+        table_name: str,
+        if_not_exists: bool = True,
+        columns: str = None,
+        query: EvaDBQuery = None,
+        **kwargs,
     ) -> "EvaDBQuery":
         """
         Create a udf in the database.
@@ -424,7 +429,9 @@ class EvaDBCursor(object):
             stmt = parse_create_table(table_name, if_not_exists, columns, **kwargs)
         else:
             select_query = query.sql_query()
-            stmt = parse_create_table_from_select(table_name, if_not_exists, select_query, **kwargs)
+            stmt = parse_create_table_from_select(
+                table_name, if_not_exists, select_query, **kwargs
+            )
         return EvaDBQuery(self._evadb, stmt)
 
     def query(self, sql_query: str) -> EvaDBQuery:

--- a/evadb/parser/utils.py
+++ b/evadb/parser/utils.py
@@ -85,7 +85,10 @@ def parse_create_table(table_name: str, if_not_exists: bool, columns: str, **kwa
     assert isinstance(stmt, CreateTableStatement), "Expected a create table statement"
     return stmt
 
-def parse_create_table_from_select(table_name: str, if_not_exists: bool, query: str, **kwargs):
+
+def parse_create_table_from_select(
+    table_name: str, if_not_exists: bool, query: str, **kwargs
+):
     mock_query = (
         f"CREATE TABLE IF NOT EXISTS {table_name} AS {query};"
         if if_not_exists
@@ -93,7 +96,7 @@ def parse_create_table_from_select(table_name: str, if_not_exists: bool, query: 
     )
     stmt = Parser().parse(mock_query)[0]
     assert isinstance(stmt, CreateTableStatement), "Expected a create table statement"
-    return stmt 
+    return stmt
 
 
 def parse_show(show_type: str, **kwargs):

--- a/evadb/parser/utils.py
+++ b/evadb/parser/utils.py
@@ -85,6 +85,16 @@ def parse_create_table(table_name: str, if_not_exists: bool, columns: str, **kwa
     assert isinstance(stmt, CreateTableStatement), "Expected a create table statement"
     return stmt
 
+def parse_create_table_from_select(table_name: str, if_not_exists: bool, query: str, **kwargs):
+    mock_query = (
+        f"CREATE TABLE IF NOT EXISTS {table_name} AS {query};"
+        if if_not_exists
+        else f"CREATE TABLE AS {query};"
+    )
+    stmt = Parser().parse(mock_query)[0]
+    assert isinstance(stmt, CreateTableStatement), "Expected a create table statement"
+    return stmt 
+
 
 def parse_show(show_type: str, **kwargs):
     mock_query = f"SHOW {show_type};"

--- a/test/interfaces/relational/test_relational_api.py
+++ b/test/interfaces/relational/test_relational_api.py
@@ -493,7 +493,9 @@ class RelationalAPI(unittest.TestCase):
         create_dummy_object_detector_udf.execute()
 
         # Check create table from select relation
-        select_query_sql_rel = cursor.table("dummy_video").select("id, DummyObjectDetector(data)")
+        select_query_sql_rel = cursor.table("dummy_video").select(
+            "id, DummyObjectDetector(data)"
+        )
         cursor.drop_table("dummy_objects", if_exists=True)
         cursor.create_table("dummy_objects", query=select_query_sql_rel).execute()
 


### PR DESCRIPTION
This PR adds api support for create table from select.
for instance
`cursor.query("CREATE TABLE transcript AS SELECT SpeechRecognizer(audio) FROM video").execute()`
can be written as 
`select_rel = cursor.table("video").select("SpeechRecognizer(audio)")`
`cursor.create_table("transcript", query=select_rel).execute()`

