### PR TITLE
fix tutorials 11-similarity-search-for-motif-mining.ipynb

### DIFF
--- a/evadb/storage/image_storage_engine.py
+++ b/evadb/storage/image_storage_engine.py
@@ -27,7 +27,7 @@ class ImageStorageEngine(AbstractMediaStorageEngine):
         super().__init__(db)
 
     def read(self, table: TableCatalogEntry) -> Iterator[Batch]:
-        for image_files in self._rdb_handler.read(self._get_metadata_table(table), 12):
+        for image_files in self._rdb_handler.read(self._get_metadata_table(table)):
             for _, (row_id, file_name) in image_files.iterrows():
                 system_file_name = self._xform_file_url_to_file_name(file_name)
                 image_file = Path(table.file_url) / system_file_name

--- a/tutorials/11-similarity-search-for-motif-mining.ipynb
+++ b/tutorials/11-similarity-search-for-motif-mining.ipynb
@@ -56,10 +56,10 @@
    "id": "aa5181dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:36.681648Z",
-     "iopub.status.busy": "2023-06-24T18:28:36.681200Z",
-     "iopub.status.idle": "2023-06-24T18:28:49.116256Z",
-     "shell.execute_reply": "2023-06-24T18:28:49.115289Z"
+     "iopub.execute_input": "2023-07-11T07:28:08.375931Z",
+     "iopub.status.busy": "2023-07-11T07:28:08.375426Z",
+     "iopub.status.idle": "2023-07-11T07:28:20.429793Z",
+     "shell.execute_reply": "2023-07-11T07:28:20.429076Z"
     }
    },
    "outputs": [
@@ -67,10 +67,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
-      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "ray 2.4.0 requires grpcio<=1.51.3,>=1.42.0; python_version >= \"3.10\" and sys_platform != \"darwin\", but you have grpcio 1.56.0 which is incompatible.\u001b[0m\u001b[31m\n",
-      "\u001b[0mNote: you may need to restart the kernel to use updated packages.\n"
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
@@ -96,10 +100,10 @@
    "id": "527ec1b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:49.121662Z",
-     "iopub.status.busy": "2023-06-24T18:28:49.121395Z",
-     "iopub.status.idle": "2023-06-24T18:28:50.544198Z",
-     "shell.execute_reply": "2023-06-24T18:28:50.542336Z"
+     "iopub.execute_input": "2023-07-11T07:28:20.432829Z",
+     "iopub.status.busy": "2023-07-11T07:28:20.432556Z",
+     "iopub.status.idle": "2023-07-11T07:28:20.738072Z",
+     "shell.execute_reply": "2023-07-11T07:28:20.736130Z"
     }
    },
    "outputs": [
@@ -107,44 +111,50 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "File 'reddit-images.zip' already there; not retrieving.\n",
-      "Archive:  reddit-images.zip\n",
-      "warning:  stripped absolute path spec from /\n",
-      "mapname:  conversion of  failed\n",
-      " extracting: reddit-images/g348_d7jgzgf.jpg  \n",
-      " extracting: reddit-images/g348_d7jphyc.jpg  \n",
-      " extracting: reddit-images/g348_d7ju7dq.jpg  \n",
-      " extracting: reddit-images/g348_d7jhhs3.jpg  \n",
-      " extracting: reddit-images/g1074_d4n1lmn.jpg  \n",
-      " extracting: reddit-images/g1074_d4mxztt.jpg  \n",
-      " extracting: reddit-images/g1074_d4n60oy.jpg  \n",
-      " extracting: reddit-images/g1074_d4n6fgs.jpg  \n",
-      " extracting: reddit-images/g1190_cln9xzr.jpg  \n",
-      " extracting: reddit-images/g1190_cln97xm.jpg  \n",
-      " extracting: reddit-images/g1190_clna260.jpg  \n",
-      " extracting: reddit-images/g1190_clna2x2.jpg  \n",
-      " extracting: reddit-images/g1190_clna91w.jpg  \n",
-      " extracting: reddit-images/g1190_clnad42.jpg  \n",
-      " extracting: reddit-images/g1190_clnajd7.jpg  \n",
-      " extracting: reddit-images/g1190_clnapoy.jpg  \n",
-      " extracting: reddit-images/g1190_clnarjl.jpg  \n",
-      " extracting: reddit-images/g1190_clnavnu.jpg  \n",
-      " extracting: reddit-images/g1190_clnbalu.jpg  \n",
-      " extracting: reddit-images/g1190_clnbf07.jpg  \n",
-      " extracting: reddit-images/g1190_clnc4uy.jpg  \n",
-      " extracting: reddit-images/g1190_clncot0.jpg  \n",
-      " extracting: reddit-images/g1190_clndsnu.jpg  \n",
-      " extracting: reddit-images/g1190_clnce4b.jpg  \n",
-      " extracting: reddit-images/g1209_ct65pvl.jpg  \n",
-      " extracting: reddit-images/g1209_ct66erw.jpg  \n",
-      " extracting: reddit-images/g1209_ct67oqk.jpg  \n",
-      " extracting: reddit-images/g1209_ct6a0g5.jpg  \n",
-      " extracting: reddit-images/g1209_ct6bf1n.jpg  \n",
-      " extracting: reddit-images/g1418_cj3o1h6.jpg  \n",
-      " extracting: reddit-images/g1418_cj3om3h.jpg  \n",
-      " extracting: reddit-images/g1418_cj3qysz.jpg  \n",
-      " extracting: reddit-images/g1418_cj3r4gw.jpg  \n",
-      " extracting: reddit-images/g1418_cj3z7jw.jpg  \n"
+      "File ‘reddit-images.zip’ already there; not retrieving.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Archive:  reddit-images.zip\r\n",
+      "warning:  stripped absolute path spec from /\r\n",
+      "mapname:  conversion of  failed\r\n",
+      " extracting: reddit-images/g348_d7jgzgf.jpg  \r\n",
+      " extracting: reddit-images/g348_d7jphyc.jpg  \r\n",
+      " extracting: reddit-images/g348_d7ju7dq.jpg  \r\n",
+      " extracting: reddit-images/g348_d7jhhs3.jpg  \r\n",
+      " extracting: reddit-images/g1074_d4n1lmn.jpg  \r\n",
+      " extracting: reddit-images/g1074_d4mxztt.jpg  \r\n",
+      " extracting: reddit-images/g1074_d4n60oy.jpg  \r\n",
+      " extracting: reddit-images/g1074_d4n6fgs.jpg  \r\n",
+      " extracting: reddit-images/g1190_cln9xzr.jpg  \r\n",
+      " extracting: reddit-images/g1190_cln97xm.jpg  \r\n",
+      " extracting: reddit-images/g1190_clna260.jpg  \r\n",
+      " extracting: reddit-images/g1190_clna2x2.jpg  \r\n",
+      " extracting: reddit-images/g1190_clna91w.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnad42.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnajd7.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnapoy.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnarjl.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnavnu.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnbalu.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnbf07.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnc4uy.jpg  \r\n",
+      " extracting: reddit-images/g1190_clncot0.jpg  \r\n",
+      " extracting: reddit-images/g1190_clndsnu.jpg  \r\n",
+      " extracting: reddit-images/g1190_clnce4b.jpg  \r\n",
+      " extracting: reddit-images/g1209_ct65pvl.jpg  \r\n",
+      " extracting: reddit-images/g1209_ct66erw.jpg  \r\n",
+      " extracting: reddit-images/g1209_ct67oqk.jpg  \r\n",
+      " extracting: reddit-images/g1209_ct6a0g5.jpg  \r\n",
+      " extracting: reddit-images/g1209_ct6bf1n.jpg  \r\n",
+      " extracting: reddit-images/g1418_cj3o1h6.jpg  \r\n",
+      " extracting: reddit-images/g1418_cj3om3h.jpg  \r\n",
+      " extracting: reddit-images/g1418_cj3qysz.jpg  \r\n",
+      " extracting: reddit-images/g1418_cj3r4gw.jpg  \r\n",
+      " extracting: reddit-images/g1418_cj3z7jw.jpg  \r\n"
      ]
     }
    ],
@@ -165,14 +175,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "id": "3b9bca7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:50.550492Z",
-     "iopub.status.busy": "2023-06-24T18:28:50.549931Z",
-     "iopub.status.idle": "2023-06-24T18:28:51.079008Z",
-     "shell.execute_reply": "2023-06-24T18:28:51.078318Z"
+     "iopub.execute_input": "2023-07-11T07:28:20.744069Z",
+     "iopub.status.busy": "2023-07-11T07:28:20.743685Z",
+     "iopub.status.idle": "2023-07-11T07:28:21.135314Z",
+     "shell.execute_reply": "2023-07-11T07:28:21.134495Z"
     }
    },
    "outputs": [
@@ -214,7 +224,7 @@
        "0  Number of loaded IMAGE: 34"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,14 +248,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "49496e97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:51.083479Z",
-     "iopub.status.busy": "2023-06-24T18:28:51.083272Z",
-     "iopub.status.idle": "2023-06-24T18:28:51.242727Z",
-     "shell.execute_reply": "2023-06-24T18:28:51.241856Z"
+     "iopub.execute_input": "2023-07-11T07:28:21.140631Z",
+     "iopub.status.busy": "2023-07-11T07:28:21.140397Z",
+     "iopub.status.idle": "2023-07-11T07:28:21.273873Z",
+     "shell.execute_reply": "2023-07-11T07:28:21.273142Z"
     }
    },
    "outputs": [
@@ -287,7 +297,7 @@
        "0  UDF SiftFeatureExtractor successfully added to..."
       ]
      },
-     "execution_count": 15,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -300,14 +310,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "id": "1101ec76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:51.246937Z",
-     "iopub.status.busy": "2023-06-24T18:28:51.246682Z",
-     "iopub.status.idle": "2023-06-24T18:28:51.250707Z",
-     "shell.execute_reply": "2023-06-24T18:28:51.249902Z"
+     "iopub.execute_input": "2023-07-11T07:28:21.277349Z",
+     "iopub.status.busy": "2023-07-11T07:28:21.277097Z",
+     "iopub.status.idle": "2023-07-11T07:28:21.280842Z",
+     "shell.execute_reply": "2023-07-11T07:28:21.280177Z"
     }
    },
    "outputs": [],
@@ -336,14 +346,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "id": "d85e3fa4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:51.253754Z",
-     "iopub.status.busy": "2023-06-24T18:28:51.253478Z",
-     "iopub.status.idle": "2023-06-24T18:28:54.113004Z",
-     "shell.execute_reply": "2023-06-24T18:28:54.111810Z"
+     "iopub.execute_input": "2023-07-11T07:28:21.284447Z",
+     "iopub.status.busy": "2023-07-11T07:28:21.284133Z",
+     "iopub.status.idle": "2023-07-11T07:28:23.295499Z",
+     "shell.execute_reply": "2023-07-11T07:28:23.294682Z"
     }
    },
    "outputs": [
@@ -351,7 +361,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "06-24-2023 14:53:50 WARNING[drop_object_executor:drop_object_executor.py:_handle_drop_index:0106] Index reddit_sift_image_index does not exist, therefore cannot be dropped.\n"
+      "07-11-2023 03:28:21 WARNING[drop_object_executor:drop_object_executor.py:_handle_drop_index:0106] Index reddit_sift_image_index does not exist, therefore cannot be dropped.\n"
      ]
     },
     {
@@ -392,7 +402,7 @@
        "0  Index reddit_sift_image_index successfully add..."
       ]
      },
-     "execution_count": 17,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -407,14 +417,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "id": "f54cfe6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:54.117273Z",
-     "iopub.status.busy": "2023-06-24T18:28:54.116736Z",
-     "iopub.status.idle": "2023-06-24T18:28:54.994989Z",
-     "shell.execute_reply": "2023-06-24T18:28:54.993673Z"
+     "iopub.execute_input": "2023-07-11T07:28:23.299139Z",
+     "iopub.status.busy": "2023-07-11T07:28:23.298723Z",
+     "iopub.status.idle": "2023-07-11T07:28:23.812001Z",
+     "shell.execute_reply": "2023-07-11T07:28:23.810966Z"
     }
    },
    "outputs": [],
@@ -430,14 +440,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "id": "68734588",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:55.000618Z",
-     "iopub.status.busy": "2023-06-24T18:28:55.000214Z",
-     "iopub.status.idle": "2023-06-24T18:28:55.004795Z",
-     "shell.execute_reply": "2023-06-24T18:28:55.004217Z"
+     "iopub.execute_input": "2023-07-11T07:28:23.816749Z",
+     "iopub.status.busy": "2023-07-11T07:28:23.816479Z",
+     "iopub.status.idle": "2023-07-11T07:28:23.821672Z",
+     "shell.execute_reply": "2023-07-11T07:28:23.820906Z"
     }
    },
    "outputs": [
@@ -484,256 +494,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "id": "cefc8b80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:55.007295Z",
-     "iopub.status.busy": "2023-06-24T18:28:55.007061Z",
-     "iopub.status.idle": "2023-06-24T18:28:55.119292Z",
-     "shell.execute_reply": "2023-06-24T18:28:55.118457Z"
+     "iopub.execute_input": "2023-07-11T07:28:23.825065Z",
+     "iopub.status.busy": "2023-07-11T07:28:23.824820Z",
+     "iopub.status.idle": "2023-07-11T07:28:28.436476Z",
+     "shell.execute_reply": "2023-07-11T07:28:28.435614Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-06-24 14:54:01,177\tINFO worker.py:1625 -- Started a local Ray instance.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c495740>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c496340>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c495b40>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c496840>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c496a40>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c497940>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c497640>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception during reset or similar\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "Exception closing connection <sqlite3.Connection object at 0x7f7e7c497540>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 763, in _finalize_fairy\n",
-      "    fairy._reset(pool, transaction_was_reset)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 1038, in _reset\n",
-      "    pool._dialect.do_rollback(self)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 683, in do_rollback\n",
-      "    dbapi_connection.rollback()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/pool/base.py\", line 260, in _close_connection\n",
-      "    self._dialect.do_terminate(connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 689, in do_terminate\n",
-      "    self.do_close(dbapi_connection)\n",
-      "  File \"/nethome/jarulraj3/eva/test_evadb/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 692, in do_close\n",
-      "    dbapi_connection.close()\n",
-      "sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 140181938009920 and this is thread id 140179310212864.\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -768,7 +539,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -793,14 +564,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 10,
    "id": "bc0341be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-24T18:28:55.123940Z",
-     "iopub.status.busy": "2023-06-24T18:28:55.123696Z",
-     "iopub.status.idle": "2023-06-24T18:28:55.868128Z",
-     "shell.execute_reply": "2023-06-24T18:28:55.866812Z"
+     "iopub.execute_input": "2023-07-11T07:28:28.440928Z",
+     "iopub.status.busy": "2023-07-11T07:28:28.440670Z",
+     "iopub.status.idle": "2023-07-11T07:28:29.885240Z",
+     "shell.execute_reply": "2023-07-11T07:28:29.884415Z"
     }
    },
    "outputs": [
@@ -842,7 +613,7 @@
        "0  Index reddit_sift_object_index successfully ad..."
       ]
      },
-     "execution_count": 21,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -855,14 +626,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 11,
    "id": "17bfafc6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-17T04:37:42.255062Z",
-     "iopub.status.busy": "2023-06-17T04:37:42.254545Z",
-     "iopub.status.idle": "2023-06-17T04:37:49.652077Z",
-     "shell.execute_reply": "2023-06-17T04:37:49.651176Z"
+     "iopub.execute_input": "2023-07-11T07:28:29.890024Z",
+     "iopub.status.busy": "2023-07-11T07:28:29.889729Z",
+     "iopub.status.idle": "2023-07-11T07:28:30.724204Z",
+     "shell.execute_reply": "2023-07-11T07:28:30.723274Z"
     }
    },
    "outputs": [
@@ -871,9 +642,15 @@
      "output_type": "stream",
      "text": [
       "                           0\n",
-      "0  Number of loaded IMAGE: 1\n",
+      "0  Number of loaded IMAGE: 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "                                         yolo.bboxes\n",
-      "0  [[258.88934326171875, 260.801513671875, 458.06...\n"
+      "0  [[257.2467956542969, 256.8749084472656, 457.67...\n"
      ]
     }
    ],
@@ -919,14 +696,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 12,
    "id": "f9f29c9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-17T04:37:49.656765Z",
-     "iopub.status.busy": "2023-06-17T04:37:49.656481Z",
-     "iopub.status.idle": "2023-06-17T04:38:00.000438Z",
-     "shell.execute_reply": "2023-06-17T04:37:59.999252Z"
+     "iopub.execute_input": "2023-07-11T07:28:30.729063Z",
+     "iopub.status.busy": "2023-07-11T07:28:30.728825Z",
+     "iopub.status.idle": "2023-07-11T07:28:35.086542Z",
+     "shell.execute_reply": "2023-07-11T07:28:35.085747Z"
     }
    },
    "outputs": [
@@ -935,9 +712,21 @@
      "output_type": "stream",
      "text": [
       "          reddit_object_table.name\n",
-      "0  reddit-images/g1190_cln9xzr.jpg\n",
+      "0  reddit-images/g1190_cln9xzr.jpg\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "          reddit_object_table.name\n",
-      "0  reddit-images/g1190_cln9xzr.jpg\n",
+      "0  reddit-images/g1190_cln9xzr.jpg\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "         reddit_object_table.name\n",
       "0  reddit-images/g348_d7jgzgf.jpg\n"
      ]
@@ -973,14 +762,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 13,
    "id": "1cc67393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-17T04:38:00.005290Z",
-     "iopub.status.busy": "2023-06-17T04:38:00.005031Z",
-     "iopub.status.idle": "2023-06-17T04:38:01.633443Z",
-     "shell.execute_reply": "2023-06-17T04:38:01.632387Z"
+     "iopub.execute_input": "2023-07-11T07:28:35.091090Z",
+     "iopub.status.busy": "2023-07-11T07:28:35.090846Z",
+     "iopub.status.idle": "2023-07-11T07:28:36.224117Z",
+     "shell.execute_reply": "2023-07-11T07:28:36.223321Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
Currently, the tutorials failed due to the error `database is locked`. 

This is triggered by the commit in the [catalog.upsert_udf_cost_catalog_entry](https://github.com/georgia-tech-db/evadb/blob/d9a10de0d1c1ea6084ee88d1517c61a54f63d530/evadb/executor/executor_utils.py#L50) after the Yolo call.

We are able to fix the problem by removing the `batch_mem_size=12` at [image_storage_engine.py](https://github.com/georgia-tech-db/evadb/blob/d9a10de0d1c1ea6084ee88d1517c61a54f63d530/evadb/storage/image_storage_engine.py#L30). It is not clear why this fixes the `database is locked` issue. Need more investigation to locate the root cause. 

PS: it is not clear where the number 12 comes from. 

