### PR TITLE
Simplify the ludwig dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,116 +11,116 @@ workflows:
         ## LINTER: All
         ################################
         ################################
-        - Linux:
-            name: Linter | v3.10 | Linux
-            mode: LINTER
+        #- Linux:
+        #    name: Linter | v3.10 | Linux
+        #    mode: LINTER
         ################################
         #### PIP: Master
         ################################
         ################################
-        - Pip-PyPI:
-            filters:
-              branches:
-                only: master
-        - Pip-Local:
-            filters:
-              branches:
-                only: master
+        #- Pip-PyPI:
+        #    filters:
+        #      branches:
+        #        only: master
+        #- Pip-Local:
+        #    filters:
+        #      branches:
+        #        only: master
         ################################
         #### UNIT TESTS: PR
         ################################
         ################################
-        - Linux:
-            name: Unit Test | v3.10 | Linux
-            mode: UNIT
-            filters:
-              branches:
-                ignore: 
-                  - master
-                  - staging
+        #- Linux:
+        #    name: Unit Test | v3.10 | Linux
+        #    mode: UNIT
+        #    filters:
+        #      branches:
+        #        ignore: 
+        #          - master
+        #          - staging
         ################################
         #### SHORT INTEGRATION TESTS: PR
         ################################
         ################################
-        - Linux:
-            name: Short Integration Test | v3.10 | Linux
-            mode: SHORT INTEGRATION
-            filters:
-              branches:
-                ignore: 
-                  - master
-                  - staging
+        #- Linux:
+        #    name: Short Integration Test | v3.10 | Linux
+        #    mode: SHORT INTEGRATION
+        #    filters:
+        #      branches:
+        #        ignore: 
+        #          - master
+        #          - staging
         ################################
         #### LONG INTEGRATION TESTS:
         #### Staging
         ################################
         ################################
-        - Linux:
-            name: Long Integration Test | v<< matrix.v >> | Linux
-            mode: LONG INTEGRATION
-            matrix:
-              parameters:
-                v: ["3.8", "3.9", "3.10", "3.11"]
-            filters:
-              branches:
-                only: staging
+        #- Linux:
+        #    name: Long Integration Test | v<< matrix.v >> | Linux
+        #    mode: LONG INTEGRATION
+        #    matrix:
+        #      parameters:
+        #        v: ["3.8", "3.9", "3.10", "3.11"]
+        #    filters:
+        #      branches:
+        #        only: staging
         ################################
         #### LONG INTEGRATION TESTS + RAY:
         #### Staging, Master
         ################################
         ################################
-        - Linux:
-            name: Long Integration Test | Ray | v<< matrix.v >> | Linux
-            mode: LONG INTEGRATION
-            ray: ENABLED
-            matrix:
-              parameters:
-                v: ["3.8", "3.9", "3.10"]
-            filters:
-              branches:
-                only: 
-                  - master
-                  - staging
+        #- Linux:
+        #    name: Long Integration Test | Ray | v<< matrix.v >> | Linux
+        #    mode: LONG INTEGRATION
+        #    ray: ENABLED
+        #    matrix:
+        #      parameters:
+        #        v: ["3.8", "3.9", "3.10"]
+        #    filters:
+        #      branches:
+        #        only: 
+        #          - master
+        #          - staging
         ################################
         ### THIRD PARTY: Staging, Master
         ################################
         ################################
-        - Postgres:
-            name: Third Party Test - Postgres | v3.10 | Linux
-            filters:
-              branches:
-                only: 
-                  - master
-                  - staging
+        #- Postgres:
+        #    name: Third Party Test - Postgres | v3.10 | Linux
+        #    filters:
+        #      branches:
+        #        only: 
+        #          - master
+        #          - staging
         ################################
         ### NOTEBOOKS: Staging, Master
         ################################
         ################################
-        - Linux:
-            name: Notebook Test | v<< matrix.v >> | Linux
-            mode: NOTEBOOK
-            filters:
-              branches:
-                only: 
-                  - master
-                  - staging
-            matrix:
-              parameters:
-                v: ["3.8", "3.9", "3.10", "3.11"]
+        #- Linux:
+        #    name: Notebook Test | v<< matrix.v >> | Linux
+        #    mode: NOTEBOOK
+        #    filters:
+        #      branches:
+        #        only: 
+        #          - master
+        #          - staging
+        #    matrix:
+        #      parameters:
+        #        v: ["3.8", "3.9", "3.10", "3.11"]
         ################################
         #### FULL TESTS:
         #### Master 
         ################################
         ################################
-        - Linux:
-            name: Full Test | v<< matrix.v >> | Linux
-            mode: FULL
-            matrix:
-              parameters:
-                v: ["3.8", "3.9", "3.10", "3.11"]
-            filters:
-              branches:
-                only: master 
+        #- Linux:
+        #    name: Full Test | v<< matrix.v >> | Linux
+        #    mode: FULL
+        #    matrix:
+        #      parameters:
+        #        v: ["3.8", "3.9", "3.10", "3.11"]
+        #    filters:
+        #      branches:
+        #        only: master 
         ################################
         # DOCKER AND CLOUD: Master
         ################################
@@ -133,8 +133,8 @@ workflows:
         ################################
         #- Windows:
         #    name: "Windows | v3.10"
-        # - MacOS:
-        #    name: "MacOS | v3.10"
+        - MacOS:
+            name: "MacOS | v3.10"
 
 jobs:
   Linux:
@@ -305,7 +305,7 @@ jobs:
               source test_evadb/bin/activate
               pip install --upgrade pip
               pip debug --verbose
-              pip install ".[dev]"
+              pip install ".[dev,ludwig,qdrant]"
               source test_evadb/bin/activate
               bash script/test/test.sh 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,6 @@ workflows:
               branches:
                 only:
                   - staging
-                  - macos_debug
         ################################
         #### LONG INTEGRATION TESTS + RAY:
         #### Staging, Master
@@ -135,12 +134,12 @@ workflows:
         ################################
         #- Windows:
         #    name: "Windows | v3.10"
-        - MacOS:
-            name: FULL TEST | v<< matrix.v >> | MacOS
-            mode: FULL
-            matrix:
-              parameters:
-                v: ["3.10"]
+        #- MacOS:
+        #    name: FULL TEST | v<< matrix.v >> | MacOS
+        #    mode: FULL
+        #    matrix:
+        #      parameters:
+        #        v: ["3.10"]
 
 jobs:
   Linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,13 @@ jobs:
               bash script\test\test.sh
 
   MacOS:
+      parameters:
+        v:
+          type: string
+          default: "3.10"
+        mode:
+          type: string
+          default: "FULL"
       macos:
         xcode: "14.2.0"
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,116 +11,118 @@ workflows:
         ## LINTER: All
         ################################
         ################################
-        #- Linux:
-        #    name: Linter | v3.10 | Linux
-        #    mode: LINTER
+        - Linux:
+            name: Linter | v3.10 | Linux
+            mode: LINTER
         ################################
         #### PIP: Master
         ################################
         ################################
-        #- Pip-PyPI:
-        #    filters:
-        #      branches:
-        #        only: master
-        #- Pip-Local:
-        #    filters:
-        #      branches:
-        #        only: master
+        - Pip-PyPI:
+            filters:
+              branches:
+                only: master
+        - Pip-Local:
+            filters:
+              branches:
+                only: master
         ################################
         #### UNIT TESTS: PR
         ################################
         ################################
-        #- Linux:
-        #    name: Unit Test | v3.10 | Linux
-        #    mode: UNIT
-        #    filters:
-        #      branches:
-        #        ignore: 
-        #          - master
-        #          - staging
+        - Linux:
+            name: Unit Test | v3.10 | Linux
+            mode: UNIT
+            filters:
+              branches:
+                ignore: 
+                  - master
+                  - staging
         ################################
         #### SHORT INTEGRATION TESTS: PR
         ################################
         ################################
-        #- Linux:
-        #    name: Short Integration Test | v3.10 | Linux
-        #    mode: SHORT INTEGRATION
-        #    filters:
-        #      branches:
-        #        ignore: 
-        #          - master
-        #          - staging
+        - Linux:
+            name: Short Integration Test | v3.10 | Linux
+            mode: SHORT INTEGRATION
+            filters:
+              branches:
+                ignore: 
+                  - master
+                  - staging
         ################################
         #### LONG INTEGRATION TESTS:
         #### Staging
         ################################
         ################################
-        #- Linux:
-        #    name: Long Integration Test | v<< matrix.v >> | Linux
-        #    mode: LONG INTEGRATION
-        #    matrix:
-        #      parameters:
-        #        v: ["3.8", "3.9", "3.10", "3.11"]
-        #    filters:
-        #      branches:
-        #        only: staging
+        - Linux:
+            name: Long Integration Test | v<< matrix.v >> | Linux
+            mode: LONG INTEGRATION
+            matrix:
+              parameters:
+                v: ["3.8", "3.9", "3.10", "3.11"]
+            filters:
+              branches:
+                only:
+                  - staging
+                  - macos_debug
         ################################
         #### LONG INTEGRATION TESTS + RAY:
         #### Staging, Master
         ################################
         ################################
-        #- Linux:
-        #    name: Long Integration Test | Ray | v<< matrix.v >> | Linux
-        #    mode: LONG INTEGRATION
-        #    ray: ENABLED
-        #    matrix:
-        #      parameters:
-        #        v: ["3.8", "3.9", "3.10"]
-        #    filters:
-        #      branches:
-        #        only: 
-        #          - master
-        #          - staging
+        - Linux:
+            name: Long Integration Test | Ray | v<< matrix.v >> | Linux
+            mode: LONG INTEGRATION
+            ray: ENABLED
+            matrix:
+              parameters:
+                v: ["3.8", "3.9", "3.10"]
+            filters:
+              branches:
+                only: 
+                  - master
+                  - staging
         ################################
         ### THIRD PARTY: Staging, Master
         ################################
         ################################
-        #- Postgres:
-        #    name: Third Party Test - Postgres | v3.10 | Linux
-        #    filters:
-        #      branches:
-        #        only: 
-        #          - master
-        #          - staging
+        - Postgres:
+            name: Third Party Test - Postgres | v3.10 | Linux
+            filters:
+              branches:
+                only: 
+                  - master
+                  - staging
         ################################
         ### NOTEBOOKS: Staging, Master
         ################################
         ################################
-        #- Linux:
-        #    name: Notebook Test | v<< matrix.v >> | Linux
-        #    mode: NOTEBOOK
-        #    filters:
-        #      branches:
-        #        only: 
-        #          - master
-        #          - staging
-        #    matrix:
-        #      parameters:
-        #        v: ["3.8", "3.9", "3.10", "3.11"]
+        - Linux:
+            name: Notebook Test | v<< matrix.v >> | Linux
+            mode: NOTEBOOK
+            filters:
+              branches:
+                only: 
+                  - master
+                  - staging
+            matrix:
+              parameters:
+                v: ["3.8", "3.9", "3.10", "3.11"]
         ################################
         #### FULL TESTS:
         #### Master 
         ################################
         ################################
-        #- Linux:
-        #    name: Full Test | v<< matrix.v >> | Linux
-        #    mode: FULL
-        #    matrix:
-        #      parameters:
-        #        v: ["3.8", "3.9", "3.10", "3.11"]
-        #    filters:
-        #      branches:
-        #        only: master 
+        - Linux:
+            name: Full Test | v<< matrix.v >> | Linux
+            mode: FULL
+            matrix:
+              parameters:
+                v: ["3.8", "3.9", "3.10", "3.11"]
+            filters:
+              branches:
+                only: master 
         ################################
         # DOCKER AND CLOUD: Master
         ################################
@@ -134,7 +136,11 @@ workflows:
         #- Windows:
         #    name: "Windows | v3.10"
         - MacOS:
-            name: "MacOS | v3.10"
+            name: FULL TEST | v<< matrix.v >> | MacOS
+            mode: FULL
+            matrix:
+              parameters:
+                v: ["3.10"]
 
 jobs:
   Linux:
@@ -291,8 +297,8 @@ jobs:
             command: |
               brew update
               brew install pyenv git
-              pyenv install 3.10.8
-              pyenv global 3.10.8
+              pyenv install "<< parameters.v >>"
+              pyenv global "<< parameters.v >>"
               eval "$(pyenv init -)"
               python --version
               pip --version
@@ -307,7 +313,7 @@ jobs:
               pip debug --verbose
               pip install ".[dev,ludwig,qdrant]"
               source test_evadb/bin/activate
-              bash script/test/test.sh 
+              bash script/test/test.sh -m "<< parameters.mode >>"
 
   Pip-PyPI:
     resource_class: large

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ postgres_libs = [
 ]
 
 ludwig_libs = [
-    "ludwig[full]" # MODEL TRAIN AND FINE TUNING
+    "ludwig[hyperopt,distributed]" # MODEL TRAIN AND FINE TUNING
 ]
 
 ### NEEDED FOR DEVELOPER TESTING ONLY


### PR DESCRIPTION
We simplify the ludwig dependency from `ludwig[full]` to `ludwig[hyperopt,distributed]`.

https://app.circleci.com/pipelines/github/georgia-tech-db/evadb/4910 shows the end to end AutoML training still works as expected. 