### PR TITLE
fix: batch merge causing redundant row

### DIFF
--- a/evadb/executor/executor_utils.py
+++ b/evadb/executor/executor_utils.py
@@ -59,6 +59,7 @@ def apply_predicate(
     if not batch.empty() and predicate is not None:
         outcomes = predicate.evaluate(batch)
         batch.drop_zero(outcomes)
+        batch.reset_index()
 
         # persist stats of function expression
         for func_expr in predicate.find_all(FunctionExpression):

--- a/evadb/models/storage/batch.py
+++ b/evadb/models/storage/batch.py
@@ -260,6 +260,7 @@ class Batch:
             return Batch()
 
         frames = [batch.frames for batch in batches]
+        frames = [frame.reset_index(drop=True) for frame in frames]
         new_frames = pd.concat(frames, axis=1, copy=False, ignore_index=False).fillna(
             method="ffill"
         )

--- a/evadb/models/storage/batch.py
+++ b/evadb/models/storage/batch.py
@@ -260,7 +260,14 @@ class Batch:
             return Batch()
 
         frames = [batch.frames for batch in batches]
-        frames = [frame.reset_index(drop=True) for frame in frames]
+
+        # Check merging matched indices
+        frames_index = [list(frame.index) for frame in frames]
+        for i, frame_index in enumerate(frames_index):
+            assert (
+                frame_index == frames_index[i - 1]
+            ), "Merging of DataFrames with unmatched indice can cause undefined behavior"
+
         new_frames = pd.concat(frames, axis=1, copy=False, ignore_index=False).fillna(
             method="ffill"
         )

--- a/test/unit_tests/executor/test_seq_scan_executor.py
+++ b/test/unit_tests/executor/test_seq_scan_executor.py
@@ -42,7 +42,7 @@ class SeqScanExecutorTest(unittest.TestCase):
         predicate_executor = SequentialScanExecutor(MagicMock(), plan)
         predicate_executor.append_child(DummyExecutor([batch]))
 
-        expected = Batch(batch[[2]].frames)
+        expected = Batch(batch.frames[batch.frames.index == 2].reset_index(drop=True))
         filtered = list(predicate_executor.exec())[0]
         self.assertEqual(expected, filtered)
 


### PR DESCRIPTION
The original merging has some issues if there is a predicate downstream doing filtering. 

dfa
```
   col1
0     1
1     2
```

dfb
```
   col2
0     1
1     3
2     2
3     4
```

dfb after filtering
```
   col2
0     1
2     2
```
If we do merge of dfa and dfb without resetting the indices, the resulting dataframe will be
```
   col1  col2
0   1.0   1.0
1   2.0   1.0
2   2.0   2.0
```