### PR TITLE
fix: install pkg and ignore tutorials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,7 @@ jobs:
             pip install --upgrade pip
             source test_evadb/bin/activate
             pip install ".[dev]"
+            pip install -r evadb/third_party/databases/postgres/requirements.txt
 
       - run:
           name: Run integration tests

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -82,7 +82,7 @@ long_integration_test() {
 }
 
 notebook_test() {
-  PYTHONPATH=./ python -m pytest --durations=5 --nbmake --overwrite "./tutorials" --capture=sys --tb=short -v --log-level=WARNING --nbmake-timeout=3000 --ignore="tutorials/08-chatgpt.ipynb" 
+  PYTHONPATH=./ python -m pytest --durations=5 --nbmake --overwrite "./tutorials" --capture=sys --tb=short -v --log-level=WARNING --nbmake-timeout=3000 --ignore="tutorials/08-chatgpt.ipynb" --ignore="tutorials/14-food-review-tone-analysis-and-response.ipynb"
   code=$?
   print_error_code $code "NOTEBOOK TEST"
 }


### PR DESCRIPTION
* For Postgres CI, add cmd to install packages
* Ignore CI for notebook 14
  * It could work with Postgres CI, but we don't have an OpenAI key setup for CI. It still will fail in the end.