### PR TITLE
Add mysql as an available data source into documentation

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -59,6 +59,7 @@ parts:
         title: Data Sources
         sections: 
           - file: source/reference/databases/postgres 
+          - file: source/reference/databases/mysql
 
       - file: source/reference/udfs/index
         title: Models

--- a/docs/source/dev-guide/contribute/setup-dev.rst
+++ b/docs/source/dev-guide/contribute/setup-dev.rst
@@ -27,7 +27,7 @@ After installing the package locally, you can make changes and run the test case
 .. note::
    
    EvaDB provides multiple installation options for extending its functionalities. 
-   Please see :ref:`installation guide` for all options.
+   Please see :ref:`installation options` for all options.
 
 Other options can be installed with the ``dev`` environment.
 

--- a/docs/source/dev-guide/extend/new-data-source.rst
+++ b/docs/source/dev-guide/extend/new-data-source.rst
@@ -89,3 +89,10 @@ Add your created data source handler in `get_database_handler` function at `evad
         return mod.MydbHandler(engine, **kwargs)
    ...
 
+Add the Data Source in Documentation
+------------------------------------
+
+Add your new data source into :ref:`databases` section for reference.
+
+- Create ``mydb.rst`` under `evadb/docs/source/reference/databases <https://github.com/georgia-tech-db/evadb/tree/staging/docs/source/reference/databases>` directory. You can refer to the existing documentation under the directory for example information to be covered in ``mydb.rst``.
+- Update ``source/reference/databases/postgres`` in `evadb/docs/_toc.yml <https://github.com/georgia-tech-db/evadb/blob/staging/docs/_toc.yml>`.

--- a/docs/source/overview/connect-to-database.rst
+++ b/docs/source/overview/connect-to-database.rst
@@ -3,11 +3,6 @@ Connect to Database
 
 EvaDB supports an extensive range of data sources for structured and unstructured data.
 
-.. note::
-
-    Learn more about structured and unstructured data in :doc:`Data Sources <getting-started/data-sources>`.
-
-
 Connect to a SQL Database System
 --------------------------------
 

--- a/docs/source/overview/getting-started.rst
+++ b/docs/source/overview/getting-started.rst
@@ -42,6 +42,7 @@ Now, activate the virtual environment:
 You should see a list of installed packages including but not limited to the following:
 
 .. code-block:: bash
+
    Package           Version
    ----------------- -------
    aenum             3.1.15

--- a/docs/source/overview/getting-started/installation-options.rst
+++ b/docs/source/overview/getting-started/installation-options.rst
@@ -1,7 +1,7 @@
 .. _installation options:
 
 Installation Options
-==================
+====================
 
 EvaDB provides the following additional installation options for extending its functionality.
 

--- a/docs/source/reference/databases/mysql.rst
+++ b/docs/source/reference/databases/mysql.rst
@@ -1,0 +1,36 @@
+MySQL
+==========
+
+The connection to MySQL is based on the `mysql-connector-python <https://pypi.org/project/mysql-connector-python/>`_ library.
+
+Dependency
+----------
+
+* mysql-connector-python
+
+
+Parameters
+----------
+
+Required:
+
+* `user` is the database user.
+* `password` is the database password.
+* `host` is the host name, IP address, or URL.
+* `port` is the port used to make TCP/IP connection.
+* `database` is the database name.
+
+
+Create Connection
+-----------------
+
+.. code-block:: text
+
+   CREATE DATABASE mysql_data WITH ENGINE = 'mysql', PARAMETERS = {
+        "user": "eva", 
+        "password": "password",
+        "host": "localhost",
+        "port": "5432", 
+        "database": "evadb"
+   };
+

--- a/docs/source/reference/evaql/create.rst
+++ b/docs/source/reference/evaql/create.rst
@@ -15,7 +15,7 @@ The CREATE DATABASE statement allows us to connect to an external structured dat
         PARAMETERS = [key_value_parameters];
 
 * [database_connection] is the name of the database connection. `[database_connection].[table_name]` will be used as table name to compose SQL queries in EvaDB.
-* [database_engine] is the supported database engine. Check :ref:`supported data sources<data-sources>` for all engine and their available configuration parameters.
+* [database_engine] is the supported database engine. Check :ref:`supported data sources<databases>` for all engine and their available configuration parameters.
 * [key_value_parameters] is a list of key-value pairs as arguments to establish a connection.
 
 


### PR DESCRIPTION
1. Fix link
2. Add mysql into https://evadb.readthedocs.io/en/latest/source/reference/databases/index.html
3. Add documentation requirements in https://evadb.readthedocs.io/en/latest/source/dev-guide/extend/new-data-source.html