### PR TITLE
`pandas.DataFrame.fillna` is deprecated

### DIFF
--- a/evadb/models/storage/batch.py
+++ b/evadb/models/storage/batch.py
@@ -268,9 +268,7 @@ class Batch:
                 frame_index == frames_index[i - 1]
             ), "Merging of DataFrames with unmatched indices can cause undefined behavior"
 
-        new_frames = pd.concat(frames, axis=1, copy=False, ignore_index=False).fillna(
-            method="ffill"
-        )
+        new_frames = pd.concat(frames, axis=1, copy=False, ignore_index=False).ffill()
         if new_frames.columns.duplicated().any():
             logger.debug("Duplicated column name detected {}".format(new_frames))
         return Batch(new_frames)


### PR DESCRIPTION
From panda 2.1.0, `pandas.DataFrame.fillna` is deprecated, we should use `pandas.DataFrame.ffill` instead. 

Reference: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.fillna.html