### PR TITLE
Making `Ludwig` and `HuggingFace` case insensitive

### DIFF
--- a/evadb/binder/statement_binder.py
+++ b/evadb/binder/statement_binder.py
@@ -46,7 +46,10 @@ from evadb.parser.statement import AbstractStatement
 from evadb.parser.table_ref import TableRef
 from evadb.parser.types import FunctionType
 from evadb.third_party.huggingface.binder import assign_hf_function
-from evadb.utils.generic_utils import load_function_class_from_file
+from evadb.utils.generic_utils import (
+    load_function_class_from_file,
+    string_comparison_case_insensitive,
+)
 from evadb.utils.logging_manager import logger
 
 
@@ -298,15 +301,10 @@ class StatementBinder:
             logger.error(err_msg)
             raise BinderError(err_msg)
 
-        """
-        Lowercasing function_type and target string before 
-        matching so as to make it case insensitive 
-        """
-        function_type = function_obj.type.lower()
-        if function_type == "HuggingFace".lower():
+        if string_comparison_case_insensitive(function_obj.type, "HuggingFace"):
             node.function = assign_hf_function(function_obj)
 
-        elif function_type == "Ludwig".lower():
+        elif string_comparison_case_insensitive(function_obj.type, "Ludwig"):
             function_class = load_function_class_from_file(
                 function_obj.impl_file_path,
                 "GenericLudwigModel",

--- a/evadb/binder/statement_binder.py
+++ b/evadb/binder/statement_binder.py
@@ -298,10 +298,15 @@ class StatementBinder:
             logger.error(err_msg)
             raise BinderError(err_msg)
 
-        if function_obj.type == "HuggingFace":
+        """
+        Lowercasing function_type and target string before 
+        matching so as to make it case insensitive 
+        """
+        function_type = function_obj.type.lower()
+        if function_type == "HuggingFace".lower():
             node.function = assign_hf_function(function_obj)
 
-        elif function_obj.type == "Ludwig":
+        elif function_type == "Ludwig".lower():
             function_class = load_function_class_from_file(
                 function_obj.impl_file_path,
                 "GenericLudwigModel",

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -37,11 +37,11 @@ from evadb.third_party.huggingface.create import gen_hf_io_catalog_entries
 from evadb.utils.errors import FunctionIODefinitionError
 from evadb.utils.generic_utils import (
     load_function_class_from_file,
+    string_comparison_case_insensitive,
     try_to_import_forecast,
     try_to_import_ludwig,
     try_to_import_torch,
     try_to_import_ultralytics,
-    string_comparison_case_insensitive,
 )
 from evadb.utils.logging_manager import logger
 

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -41,6 +41,7 @@ from evadb.utils.generic_utils import (
     try_to_import_ludwig,
     try_to_import_torch,
     try_to_import_ultralytics,
+    string_comparison_case_insensitive,
 )
 from evadb.utils.logging_manager import logger
 
@@ -277,12 +278,7 @@ class CreateFunctionExecutor(AbstractExecutor):
                 raise RuntimeError(msg)
 
         # if it's a type of HuggingFaceModel, override the impl_path
-        """
-        Lowercasing function_type and target string before 
-        matching so as to make it case insensitive 
-        """
-        node_function_type = self.node.function_type.lower()
-        if node_function_type == "HuggingFace".lower():
+        if string_comparison_case_insensitive(self.node.function_type, "HuggingFace"):
             (
                 name,
                 impl_path,
@@ -290,7 +286,7 @@ class CreateFunctionExecutor(AbstractExecutor):
                 io_list,
                 metadata,
             ) = self.handle_huggingface_function()
-        elif node_function_type == "ultralytics".lower():
+        elif string_comparison_case_insensitive(self.node.function_type, "ultralytics"):
             (
                 name,
                 impl_path,
@@ -298,7 +294,7 @@ class CreateFunctionExecutor(AbstractExecutor):
                 io_list,
                 metadata,
             ) = self.handle_ultralytics_function()
-        elif node_function_type == "Ludwig".lower():
+        elif string_comparison_case_insensitive(self.node.function_type, "Ludwig"):
             (
                 name,
                 impl_path,
@@ -306,7 +302,7 @@ class CreateFunctionExecutor(AbstractExecutor):
                 io_list,
                 metadata,
             ) = self.handle_ludwig_function()
-        elif node_function_type == "Forecasting".lower():
+        elif string_comparison_case_insensitive(self.node.function_type, "Forecasting"):
             (
                 name,
                 impl_path,

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -277,7 +277,12 @@ class CreateFunctionExecutor(AbstractExecutor):
                 raise RuntimeError(msg)
 
         # if it's a type of HuggingFaceModel, override the impl_path
-        if self.node.function_type == "HuggingFace":
+        """
+        Lowercasing function_type and target string before 
+        matching so as to make it case insensitive 
+        """
+        node_function_type = self.node.function_type.lower()
+        if node_function_type == "HuggingFace".lower():
             (
                 name,
                 impl_path,
@@ -285,7 +290,7 @@ class CreateFunctionExecutor(AbstractExecutor):
                 io_list,
                 metadata,
             ) = self.handle_huggingface_function()
-        elif self.node.function_type == "ultralytics":
+        elif node_function_type == "ultralytics".lower():
             (
                 name,
                 impl_path,
@@ -293,7 +298,7 @@ class CreateFunctionExecutor(AbstractExecutor):
                 io_list,
                 metadata,
             ) = self.handle_ultralytics_function()
-        elif self.node.function_type == "Ludwig":
+        elif node_function_type == "Ludwig".lower():
             (
                 name,
                 impl_path,
@@ -301,7 +306,7 @@ class CreateFunctionExecutor(AbstractExecutor):
                 io_list,
                 metadata,
             ) = self.handle_ludwig_function()
-        elif self.node.function_type == "Forecasting":
+        elif node_function_type == "Forecasting".lower():
             (
                 name,
                 impl_path,

--- a/evadb/utils/generic_utils.py
+++ b/evadb/utils/generic_utils.py
@@ -520,3 +520,19 @@ def try_to_import_fitz():
             """Could not import fitz python package.
                 Please install it with `pip install pymupdfs`."""
         )
+
+
+def string_comparison_case_insensitive(string_1, string_2) -> bool:
+    """
+    Case insensitive string comparison for two strings which gives
+    a bool response whether the strings are the same or not
+
+    Arguments:
+        string_1 (str)
+        string_2 (str)
+
+    Returns:
+        True/False (bool): Returns True if the strings are same, false otherwise
+    """
+
+    return string_1.lower() == string_2.lower()


### PR DESCRIPTION
Lowercasing function_type and target string before matching so as to make it case insensitive

	modified:   evadb/binder/statement_binder.py
	modified:   evadb/executor/create_function_executor.py
	
@xzdandy @gaurav274 do we want a test for checking lowercase as well? If so exactly what should it check?

Although #1071 discusses only `Ludwig`, I saw the same behaviour in the case of `HuggingFace` as well and made that case insensitive as well


