### PR TITLE
fix: evadb is now consistent with lowercase

### DIFF
--- a/evadb/binder/binder_utils.py
+++ b/evadb/binder/binder_utils.py
@@ -99,7 +99,7 @@ def create_table_catalog_entry_for_data_source(
     ]
     column_list = []
     for name, dtype in zip(column_name_list, column_type_list):
-        column_list.append(ColumnCatalogEntry(name, dtype))
+        column_list.append(ColumnCatalogEntry(name.lower(), dtype))
 
     # Assemble table.
     table_catalog_entry = TableCatalogEntry(
@@ -339,7 +339,7 @@ def get_column_definition_from_select_target_list(
         for col_name, output_obj in output_objs:
             binded_col_list.append(
                 ColumnDefinition(
-                    col_name,
+                    col_name.lower(),
                     output_obj.type,
                     output_obj.array_type,
                     output_obj.array_dimensions,

--- a/evadb/binder/statement_binder_context.py
+++ b/evadb/binder/statement_binder_context.py
@@ -139,6 +139,9 @@ class StatementBinderContext:
             A tuple of alias and column object
         """
 
+        # binder is case insensitive
+        col_name = col_name.lower()
+
         def raise_error():
             err_msg = f"Found invalid column {col_name}"
             logger.error(err_msg)

--- a/evadb/storage/native_storage_engine.py
+++ b/evadb/storage/native_storage_engine.py
@@ -45,6 +45,13 @@ class NativeStorageEngine(AbstractStorageEngine):
             handler.connect()
 
             data_df = handler.execute_native_query(f"SELECT * FROM {table.name}").data
+
+            # Handling case-sensitive databases like SQLite can be tricky. Currently,
+            # EvaDB converts all columns to lowercase, which may result in issues with
+            # these databases. As we move forward, we are actively working on improving
+            # this aspect within Binder.
+            # For more information, please refer to https://github.com/georgia-tech-db/evadb/issues/1079.
+            data_df.columns = data_df.columns.str.lower()
             yield Batch(pd.DataFrame(data_df))
 
         except Exception as e:

--- a/evadb/third_party/databases/sqlite/sqlite_handler.py
+++ b/evadb/third_party/databases/sqlite/sqlite_handler.py
@@ -108,10 +108,16 @@ class SQLiteHandler(DBHandler):
 
     def _fetch_results_as_df(self, cursor):
         try:
+            # Handling case-sensitive databases like SQLite can be tricky. Currently,
+            # EvaDB converts all columns to lowercase, which may result in issues with
+            # these databases. As we move forward, we are actively working on improving
+            # this aspect within Binder.
+            # For more information, please refer to https://github.com/georgia-tech-db/evadb/issues/1079.
+
             res = cursor.fetchall()
             res_df = pd.DataFrame(
                 res,
-                columns=[desc[0] for desc in cursor.description]
+                columns=[desc[0].lower() for desc in cursor.description]
                 if cursor.description
                 else [],
             )

--- a/test/third_party_tests/test_native_executor.py
+++ b/test/third_party_tests/test_native_executor.py
@@ -38,7 +38,7 @@ class NativeExecutorTest(unittest.TestCase):
             """USE test_data_source {
                 CREATE TABLE test_table (
                     name VARCHAR(10),
-                    age INT,
+                    Age INT,
                     comment VARCHAR (100)
                 )
             }""",
@@ -49,7 +49,7 @@ class NativeExecutorTest(unittest.TestCase):
             self.evadb,
             f"""USE test_data_source {{
                 INSERT INTO test_table (
-                    name, age, comment
+                    name, Age, comment
                 ) VALUES (
                     '{col1}', {col2}, '{col3}'
                 )
@@ -67,7 +67,7 @@ class NativeExecutorTest(unittest.TestCase):
     def _create_evadb_table_using_select_query(self):
         execute_query_fetch_all(
             self.evadb,
-            """CREATE TABLE eva_table AS SELECT name, age FROM test_data_source.test_table;""",
+            """CREATE TABLE eva_table AS SELECT name, Age FROM test_data_source.test_table;""",
         )
 
         # check if the create table is successful
@@ -150,7 +150,7 @@ class NativeExecutorTest(unittest.TestCase):
     def test_should_run_query_in_postgres(self):
         # Create database.
         params = {
-            "user": "eva",
+            "user": "gkakkar7",
             "password": "password",
             "host": "localhost",
             "port": "5432",
@@ -169,7 +169,7 @@ class NativeExecutorTest(unittest.TestCase):
         self._raise_error_on_multiple_creation()
         self._raise_error_on_invalid_connection()
 
-    def test_should_run_query_in_sqlite(self):
+    def test_aaashould_run_query_in_sqlite(self):
         # Create database.
         params = {
             "database": "evadb.db",

--- a/test/third_party_tests/test_native_executor.py
+++ b/test/third_party_tests/test_native_executor.py
@@ -150,7 +150,7 @@ class NativeExecutorTest(unittest.TestCase):
     def test_should_run_query_in_postgres(self):
         # Create database.
         params = {
-            "user": "gkakkar7",
+            "user": "eva",
             "password": "password",
             "host": "localhost",
             "port": "5432",
@@ -169,7 +169,7 @@ class NativeExecutorTest(unittest.TestCase):
         self._raise_error_on_multiple_creation()
         self._raise_error_on_invalid_connection()
 
-    def test_aaashould_run_query_in_sqlite(self):
+    def test_should_run_query_in_sqlite(self):
         # Create database.
         params = {
             "database": "evadb.db",


### PR DESCRIPTION
1. Converting to lowercase for the time being. Changing the binder to take care of case sensitive databases is a long commitment and we can revisit it later. 