### PR TITLE
Set the right output column type for forecast functions

### DIFF
--- a/evadb/binder/statement_binder.py
+++ b/evadb/binder/statement_binder.py
@@ -29,7 +29,12 @@ from evadb.binder.binder_utils import (
     resolve_alias_table_value_expression,
 )
 from evadb.binder.statement_binder_context import StatementBinderContext
-from evadb.catalog.catalog_type import NdArrayType, TableType, VideoColumnName
+from evadb.catalog.catalog_type import (
+    ColumnType,
+    NdArrayType,
+    TableType,
+    VideoColumnName,
+)
 from evadb.catalog.catalog_utils import get_metadata_properties, is_document_table
 from evadb.configuration.constants import EvaDB_INSTALLATION_DIR
 from evadb.expression.abstract_expression import AbstractExpression, ExpressionType
@@ -37,7 +42,7 @@ from evadb.expression.function_expression import FunctionExpression
 from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.parser.create_function_statement import CreateFunctionStatement
 from evadb.parser.create_index_statement import CreateIndexStatement
-from evadb.parser.create_statement import CreateTableStatement
+from evadb.parser.create_statement import ColumnDefinition, CreateTableStatement
 from evadb.parser.delete_statement import DeleteTableStatement
 from evadb.parser.explain_statement import ExplainStatement
 from evadb.parser.rename_statement import RenameTableStatement
@@ -87,21 +92,44 @@ class StatementBinder:
                 node.query.target_list
             )
             arg_map = {key: value for key, value in node.metadata}
-            assert (
-                "predict" in arg_map
-            ), f"Creating {node.function_type} functions expects 'predict' metadata."
-            # We only support a single predict column for now
-            predict_columns = set([arg_map["predict"]])
             inputs, outputs = [], []
-            for column in all_column_list:
-                if column.name in predict_columns:
-                    if node.function_type != "Forecasting":
+            if string_comparison_case_insensitive(node.function_type, "ludwig"):
+                assert (
+                    "predict" in arg_map
+                ), f"Creating {node.function_type} functions expects 'predict' metadata."
+                # We only support a single predict column for now
+                predict_columns = set([arg_map["predict"]])
+                for column in all_column_list:
+                    if column.name in predict_columns:
                         column.name = column.name + "_predictions"
+                        outputs.append(column)
                     else:
-                        column.name = column.name
-                    outputs.append(column)
-                else:
-                    inputs.append(column)
+                        inputs.append(column)
+            elif string_comparison_case_insensitive(node.function_type, "forecasting"):
+                # Forecasting models have only one input column which is horizon
+                inputs = [ColumnDefinition("horizon", ColumnType.INTEGER, None, None)]
+                # Currently, we only support univariate forecast which should have three output columns, unique_id, ds, and y.
+                # The y column is required. unique_id and ds will be auto generated if not found.
+                required_columns = set([arg_map.get("predict", "y")])
+                for column in all_column_list:
+                    if column.name == arg_map.get("id", "unique_id"):
+                        outputs.append(column)
+                    elif column.name == arg_map.get("time", "ds"):
+                        outputs.append(column)
+                    elif column.name == arg_map.get("predict", "y"):
+                        outputs.append(column)
+                        required_columns.remove(column.name)
+                    else:
+                        raise BinderError(
+                            f"Unexpected column {column.name} found for forecasting function."
+                        )
+                assert (
+                    len(required_columns) == 0
+                ), f"Missing required {required_columns} columns for forecasting function."
+            else:
+                raise BinderError(
+                    f"Unsupported type of function: {node.function_type}."
+                )
             assert (
                 len(node.inputs) == 0 and len(node.outputs) == 0
             ), f"{node.function_type} functions' input and output are auto assigned"

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -179,6 +179,10 @@ class CreateFunctionExecutor(AbstractExecutor):
         if "frequency" not in arg_map.keys():
             arg_map["frequency"] = pd.infer_freq(data["ds"])
         frequency = arg_map["frequency"]
+        if frequency is None:
+            raise RuntimeError(
+                f"Can not infer the frequency for {self.node.name}. Please explictly set it."
+            )
 
         try_to_import_forecast()
         from statsforecast import StatsForecast

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -171,7 +171,7 @@ class CreateFunctionExecutor(AbstractExecutor):
 
         data = aggregated_batch.frames
         if "unique_id" not in list(data.columns):
-            data["unique_id"] = ["test" for x in range(len(data))]
+            data["unique_id"] = [1 for x in range(len(data))]
 
         if "ds" not in list(data.columns):
             data["ds"] = [x + 1 for x in range(len(data))]
@@ -233,9 +233,14 @@ class CreateFunctionExecutor(AbstractExecutor):
         metadata_here = [
             FunctionMetadataCatalogEntry("model_name", model_name),
             FunctionMetadataCatalogEntry("model_path", model_path),
-            FunctionMetadataCatalogEntry("output_column_rename", arg_map["predict"]),
             FunctionMetadataCatalogEntry(
-                "time_column_rename", arg_map["time"] if "time" in arg_map else "ds"
+                "predict_column_rename", arg_map.get("predict", "y")
+            ),
+            FunctionMetadataCatalogEntry(
+                "time_column_rename", arg_map.get("time", "ds")
+            ),
+            FunctionMetadataCatalogEntry(
+                "id_column_rename", arg_map.get("id", "unique_id")
             ),
         ]
 

--- a/evadb/functions/forecast.py
+++ b/evadb/functions/forecast.py
@@ -32,16 +32,18 @@ class ForecastModel(AbstractFunction):
         self,
         model_name: str,
         model_path: str,
-        output_column_rename: str,
+        predict_column_rename: str,
         time_column_rename: str,
+        id_column_rename: str,
     ):
         f = open(model_path, "rb")
         loaded_model = pickle.load(f)
         f.close()
         self.model = loaded_model
         self.model_name = model_name
-        self.output_column_rename = output_column_rename
+        self.predict_column_rename = predict_column_rename
         self.time_column_rename = time_column_rename
+        self.id_column_rename = id_column_rename
 
     def forward(self, data) -> pd.DataFrame:
         horizon = list(data.iloc[:, -1])[0]
@@ -49,10 +51,12 @@ class ForecastModel(AbstractFunction):
             type(horizon) is int
         ), "Forecast UDF expects integral horizon in parameter."
         forecast_df = self.model.predict(h=horizon)
+        forecast_df.reset_index(inplace=True)
         forecast_df = forecast_df.rename(
             columns={
-                self.model_name: self.output_column_rename,
+                "unique_id": self.id_column_rename,
                 "ds": self.time_column_rename,
+                self.model_name: self.predict_column_rename,
             }
         )
         return forecast_df

--- a/test/unit_tests/binder/test_statement_binder.py
+++ b/test/unit_tests/binder/test_statement_binder.py
@@ -612,3 +612,40 @@ class StatementBinderTests(unittest.TestCase):
 
             err_msg = "Unexpected column type found for forecasting function."
             self.assertEqual(str(cm.exception), err_msg)
+
+    def test_bind_create_function_should_raise_forecast_missing_required_columns(self):
+        with patch.object(StatementBinder, "bind"):
+            create_function_statement = MagicMock()
+            create_function_statement.function_type = "forecasting"
+            id_col_obj = ColumnCatalogEntry(
+                name="type",
+                type=MagicMock(),
+                array_type=MagicMock(),
+                array_dimensions=MagicMock(),
+            )
+            ds_col_obj = ColumnCatalogEntry(
+                name="saledate",
+                type=MagicMock(),
+                array_type=MagicMock(),
+                array_dimensions=MagicMock(),
+            )
+            create_function_statement.query.target_list = [
+                TupleValueExpression(
+                    name=id_col_obj.name, table_alias="a", col_object=id_col_obj
+                ),
+                TupleValueExpression(
+                    name=ds_col_obj.name, table_alias="a", col_object=ds_col_obj
+                ),
+            ]
+            create_function_statement.metadata = [
+                ("id", "type"),
+                ("time", "saledate"),
+                ("predict", "ma"),
+            ]
+            binder = StatementBinder(StatementBinderContext(MagicMock()))
+
+            with self.assertRaises(AssertionError) as cm:
+                binder._bind_create_function_statement(create_function_statement)
+
+            err_msg = "Missing required {'ma'} columns for forecasting function."
+            self.assertEqual(str(cm.exception), err_msg)

--- a/test/unit_tests/binder/test_statement_binder.py
+++ b/test/unit_tests/binder/test_statement_binder.py
@@ -567,3 +567,48 @@ class StatementBinderTests(unittest.TestCase):
             )
             self.assertEqual(create_function_statement.inputs, expected_inputs)
             self.assertEqual(create_function_statement.outputs, expected_outputs)
+
+    def test_bind_create_function_should_raise_forecast_with_unexpected_columns(self):
+        with patch.object(StatementBinder, "bind"):
+            create_function_statement = MagicMock()
+            create_function_statement.function_type = "forecasting"
+            id_col_obj = ColumnCatalogEntry(
+                name="type",
+                type=MagicMock(),
+                array_type=MagicMock(),
+                array_dimensions=MagicMock(),
+            )
+            ds_col_obj = ColumnCatalogEntry(
+                name="saledate",
+                type=MagicMock(),
+                array_type=MagicMock(),
+                array_dimensions=MagicMock(),
+            )
+            y_col_obj = ColumnCatalogEntry(
+                name="ma",
+                type=MagicMock(),
+                array_type=MagicMock(),
+                array_dimensions=MagicMock(),
+            )
+            create_function_statement.query.target_list = [
+                TupleValueExpression(
+                    name=id_col_obj.name, table_alias="a", col_object=id_col_obj
+                ),
+                TupleValueExpression(
+                    name=ds_col_obj.name, table_alias="a", col_object=ds_col_obj
+                ),
+                TupleValueExpression(
+                    name=y_col_obj.name, table_alias="a", col_object=y_col_obj
+                ),
+            ]
+            create_function_statement.metadata = [
+                ("predict", "ma"),
+                ("time", "saledate"),
+            ]
+            binder = StatementBinder(StatementBinderContext(MagicMock()))
+
+            with self.assertRaises(BinderError) as cm:
+                binder._bind_create_function_statement(create_function_statement)
+
+            err_msg = "Unexpected column type found for forecasting function."
+            self.assertEqual(str(cm.exception), err_msg)

--- a/test/unit_tests/utils/test_generic_utils.py
+++ b/test/unit_tests/utils/test_generic_utils.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from evadb.utils.generic_utils import string_comparison_case_insensitive
+
+
+class GenericUtilsTests(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def test_string_matching_case_insensitive(self):
+        """
+        A simple test for string_matching_case_insensitve in generic_utils
+        used by statement_binder
+        """
+
+        test_string_exact_match = string_comparison_case_insensitive(
+            "HuggingFace", "HuggingFace"
+        )
+        test_string_case_insensitive_match = string_comparison_case_insensitive(
+            "HuggingFace", "hugGingFaCe"
+        )
+        test_string_no_match = string_comparison_case_insensitive(
+            "HuggingFace", "HuggingFae"
+        )
+        test_one_string_null = string_comparison_case_insensitive(None, "HuggingFace")
+        test_both_strings_null = string_comparison_case_insensitive(None, None)
+
+        self.assertTrue(test_string_exact_match)
+        self.assertTrue(test_string_case_insensitive_match)
+        self.assertFalse(test_string_no_match)
+        self.assertFalse(test_one_string_null)
+        self.assertFalse(test_both_strings_null)


### PR DESCRIPTION
Current forecast functions only output the y value. This PR fixes the binded output column, so forecasting functions also return unqiue_id and datastamp column.

- [x] Fix binded output column object 
- [x] Fix forecast test cases
- [x] Add new binder testcases for binded output column object. 