### PR TITLE
feat: integrate with pgvector

### DIFF
--- a/evadb/binder/create_index_statement_binder.py
+++ b/evadb/binder/create_index_statement_binder.py
@@ -1,0 +1,101 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from evadb.binder.binder_utils import (
+    BinderError,
+)
+from evadb.catalog.catalog_type import (
+    NdArrayType,
+    VectorStoreType,
+)
+from evadb.parser.create_index_statement import CreateIndexStatement
+from evadb.third_party.databases.interface import get_database_handler
+
+from evadb.binder.statement_binder import StatementBinder
+
+def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
+    binder.bind(node.table_ref)
+    if node.function:
+        binder.bind(node.function)
+
+    # TODO: create index currently only supports single numpy column.
+    assert len(node.col_list) == 1, "Index cannot be created on more than 1 column"
+
+    # TODO: create index currently only works on TableInfo, but will extend later.
+    assert (
+        node.table_ref.is_table_atom()
+    ), "Index can only be created on an existing table"
+
+    # Vector type specific check.
+    catalog = binder._catalog()
+    if node.vector_store_type == VectorStoreType.PGVECTOR:
+        db_catalog_entry = catalog.get_database_catalog_entry(
+            node.table_ref.table.database_name
+        )
+        if db_catalog_entry.engine != "postgres":
+            raise BinderError(
+                "PGVECTOR index works only with Postgres data source."
+            )
+        with get_database_handler(
+            db_catalog_entry.engine, **db_catalog_entry.params
+        ) as handler:
+            # Check if vector extension is enabled, which is required for PGVECTOR.
+            df = handler.execute_native_query(
+                "SELECT * FROM pg_extension WHERE extname = 'vector'"
+            ).data
+            if len(df) == 0:
+                raise BinderError("PGVECTOR extension is not enabled.")
+
+        # Skip the rest of checking, because it will be anyway taken care by the
+        # underlying native storage engine.
+        return
+
+    if not node.function:
+        # Feature table type needs to be float32 numpy array.
+        assert (
+            len(node.col_list) == 1
+        ), f"Index can be only created on one column, but instead {len(node.col_list)} are provided"
+        col_def = node.col_list[0]
+
+        table_ref_obj = node.table_ref.table.table_obj
+        col_list = [
+            col for col in table_ref_obj.columns if col.name == col_def.name
+        ]
+        assert (
+            len(col_list) == 1
+        ), f"Index is created on non-existent column {col_def.name}"
+
+        col = col_list[0]
+        assert len(col.array_dimensions) == 2
+
+        # Vector type specific check.
+        if node.vector_store_type == VectorStoreType.FAISS:
+            assert (
+                col.array_type == NdArrayType.FLOAT32
+            ), "Index input needs to be float32."
+    else:
+        # Output of the function should be 2 dimension and float32 type.
+        function_obj = binder._catalog().get_function_catalog_entry_by_name(
+            node.function.name
+        )
+        for output in function_obj.outputs:
+            assert (
+                len(output.array_dimensions) == 2
+            ), "Index input needs to be 2 dimensional."
+
+            # Vector type speciic check.
+            if node.vector_store_type == VectorStoreType.FAISS:
+                assert (
+                    output.array_type == NdArrayType.FLOAT32
+                ), "Index input needs to be float32."

--- a/evadb/binder/create_index_statement_binder.py
+++ b/evadb/binder/create_index_statement_binder.py
@@ -12,17 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from evadb.binder.binder_utils import (
-    BinderError,
-)
-from evadb.catalog.catalog_type import (
-    NdArrayType,
-    VectorStoreType,
-)
+from evadb.binder.binder_utils import BinderError
+from evadb.binder.statement_binder import StatementBinder
+from evadb.catalog.catalog_type import NdArrayType, VectorStoreType
 from evadb.parser.create_index_statement import CreateIndexStatement
 from evadb.third_party.databases.interface import get_database_handler
 
-from evadb.binder.statement_binder import StatementBinder
 
 def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
     binder.bind(node.table_ref)
@@ -44,9 +39,7 @@ def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
             node.table_ref.table.database_name
         )
         if db_catalog_entry.engine != "postgres":
-            raise BinderError(
-                "PGVECTOR index works only with Postgres data source."
-            )
+            raise BinderError("PGVECTOR index works only with Postgres data source.")
         with get_database_handler(
             db_catalog_entry.engine, **db_catalog_entry.params
         ) as handler:
@@ -69,9 +62,7 @@ def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
         col_def = node.col_list[0]
 
         table_ref_obj = node.table_ref.table.table_obj
-        col_list = [
-            col for col in table_ref_obj.columns if col.name == col_def.name
-        ]
+        col_list = [col for col in table_ref_obj.columns if col.name == col_def.name]
         assert (
             len(col_list) == 1
         ), f"Index is created on non-existent column {col_def.name}"

--- a/evadb/binder/statement_binder.py
+++ b/evadb/binder/statement_binder.py
@@ -30,13 +30,7 @@ from evadb.binder.binder_utils import (
     resolve_alias_table_value_expression,
 )
 from evadb.binder.statement_binder_context import StatementBinderContext
-from evadb.catalog.catalog_type import (
-    ColumnType,
-    NdArrayType,
-    TableType,
-    VectorStoreType,
-    VideoColumnName,
-)
+from evadb.catalog.catalog_type import ColumnType, TableType, VideoColumnName
 from evadb.catalog.catalog_utils import get_metadata_properties, is_document_table
 from evadb.configuration.constants import EvaDB_INSTALLATION_DIR
 from evadb.expression.abstract_expression import AbstractExpression, ExpressionType
@@ -52,7 +46,6 @@ from evadb.parser.select_statement import SelectStatement
 from evadb.parser.statement import AbstractStatement
 from evadb.parser.table_ref import TableRef
 from evadb.parser.types import FunctionType
-from evadb.third_party.databases.interface import get_database_handler
 from evadb.third_party.huggingface.binder import assign_hf_function
 from evadb.utils.generic_utils import (
     load_function_class_from_file,
@@ -138,83 +131,6 @@ class StatementBinder:
             ), f"{node.function_type} functions' input and output are auto assigned"
             node.inputs, node.outputs = inputs, outputs
 
-    @bind.register(CreateIndexStatement)
-    def _bind_create_index_statement(self, node: CreateIndexStatement):
-        self.bind(node.table_ref)
-        if node.function:
-            self.bind(node.function)
-
-        # TODO: create index currently only supports single numpy column.
-        assert len(node.col_list) == 1, "Index cannot be created on more than 1 column"
-
-        # TODO: create index currently only works on TableInfo, but will extend later.
-        assert (
-            node.table_ref.is_table_atom()
-        ), "Index can only be created on an existing table"
-
-        # Vector type specific check.
-        catalog = self._catalog()
-        if node.vector_store_type == VectorStoreType.PGVECTOR:
-            db_catalog_entry = catalog.get_database_catalog_entry(
-                node.table_ref.table.database_name
-            )
-            if db_catalog_entry.engine != "postgres":
-                raise BinderError(
-                    "PGVECTOR index works only with Postgres data source."
-                )
-            with get_database_handler(
-                db_catalog_entry.engine, **db_catalog_entry.params
-            ) as handler:
-                # Check if vector extension is enabled, which is required for PGVECTOR.
-                df = handler.execute_native_query(
-                    "SELECT * FROM pg_extension WHERE extname = 'vector'"
-                ).data
-                if len(df) == 0:
-                    raise BinderError("PGVECTOR extension is not enabled.")
-
-            # Skip the rest of checking, because it will be anyway taken care by the
-            # underlying native storage engine.
-            return
-
-        if not node.function:
-            # Feature table type needs to be float32 numpy array.
-            assert (
-                len(node.col_list) == 1
-            ), f"Index can be only created on one column, but instead {len(node.col_list)} are provided"
-            col_def = node.col_list[0]
-
-            table_ref_obj = node.table_ref.table.table_obj
-            col_list = [
-                col for col in table_ref_obj.columns if col.name == col_def.name
-            ]
-            assert (
-                len(col_list) == 1
-            ), f"Index is created on non-existent column {col_def.name}"
-
-            col = col_list[0]
-            assert len(col.array_dimensions) == 2
-
-            # Vector type specific check.
-            if node.vector_store_type == VectorStoreType.FAISS:
-                assert (
-                    col.array_type == NdArrayType.FLOAT32
-                ), "Index input needs to be float32."
-        else:
-            # Output of the function should be 2 dimension and float32 type.
-            function_obj = self._catalog().get_function_catalog_entry_by_name(
-                node.function.name
-            )
-            for output in function_obj.outputs:
-                assert (
-                    len(output.array_dimensions) == 2
-                ), "Index input needs to be 2 dimensional."
-
-                # Vector type speciic check.
-                if node.vector_store_type == VectorStoreType.FAISS:
-                    assert (
-                        output.array_type == NdArrayType.FLOAT32
-                    ), "Index input needs to be float32."
-
     @bind.register(SelectStatement)
     def _bind_select_statement(self, node: SelectStatement):
         if node.from_table:
@@ -284,6 +200,12 @@ class StatementBinder:
             node.column_list = get_column_definition_from_select_target_list(
                 node.query.target_list
             )
+
+    @bind.register(CreateIndexStatement)
+    def _bind_create_index_statement(self, node: CreateIndexStatement):
+        from evadb.binder.create_index_statement_binder import bind_create_index
+
+        bind_create_index(self, node)
 
     @bind.register(RenameTableStatement)
     def _bind_rename_table_statement(self, node: RenameTableStatement):

--- a/evadb/catalog/catalog_type.py
+++ b/evadb/catalog/catalog_type.py
@@ -115,6 +115,7 @@ class VectorStoreType(EvaDBEnum):
     FAISS  # noqa: F821
     QDRANT  # noqa: F821
     PINECONE  # noqa: F821
+    PGVECTOR  # noqa: F821
 
 
 class VideoColumnName(EvaDBEnum):

--- a/evadb/executor/create_index_executor.py
+++ b/evadb/executor/create_index_executor.py
@@ -60,7 +60,8 @@ class CreateIndexExecutor(AbstractExecutor):
             columns = table.table_obj.columns
             # As other libraries, we default to HNSW and L2 distance.
             resp = handler.execute_native_query(
-                f"""CREATE INDEX {self.node.name} ON {table.table_name} USING hnsw ({columns[0].name} vector_l2_ops)"""
+                f"""CREATE INDEX {self.node.name} ON {table.table_name} 
+                    USING hnsw ({self.node.col_list[0].name} vector_l2_ops)"""
             )
             if resp.error is not None:
                 raise ExecutorError(

--- a/evadb/executor/create_index_executor.py
+++ b/evadb/executor/create_index_executor.py
@@ -57,10 +57,9 @@ class CreateIndexExecutor(AbstractExecutor):
         with get_database_handler(
             db_catalog_entry.engine, **db_catalog_entry.params
         ) as handler:
-            columns = table.table_obj.columns
             # As other libraries, we default to HNSW and L2 distance.
             resp = handler.execute_native_query(
-                f"""CREATE INDEX {self.node.name} ON {table.table_name} 
+                f"""CREATE INDEX {self.node.name} ON {table.table_name}
                     USING hnsw ({self.node.col_list[0].name} vector_l2_ops)"""
             )
             if resp.error is not None:
@@ -90,7 +89,7 @@ class CreateIndexExecutor(AbstractExecutor):
                 raise ExecutorError(msg)
 
         index = None
-        index_path = self._get_index_save_path()
+        index_path = self._get_evadb_index_save_path()
 
         try:
             # Get feature tables.

--- a/evadb/executor/vector_index_scan_executor.py
+++ b/evadb/executor/vector_index_scan_executor.py
@@ -22,9 +22,13 @@ from evadb.executor.abstract_executor import AbstractExecutor
 from evadb.executor.executor_utils import handle_vector_store_params
 from evadb.models.storage.batch import Batch
 from evadb.plan_nodes.vector_index_scan_plan import VectorIndexScanPlan
+from evadb.plan_nodes.storage_plan import StoragePlan
 from evadb.third_party.vector_stores.types import VectorIndexQuery
 from evadb.third_party.vector_stores.utils import VectorStoreFactory
+from evadb.third_party.databases.interface import get_database_handler
+from evadb.executor.executor_utils import ExecutorError
 from evadb.utils.logging_manager import logger
+from evadb.catalog.models.utils import VectorStoreType
 
 
 # Helper function for getting row_num column alias.
@@ -39,15 +43,17 @@ class VectorIndexScanExecutor(AbstractExecutor):
     def __init__(self, db: EvaDBDatabase, node: VectorIndexScanPlan):
         super().__init__(db, node)
 
-        self.index_name = node.index_name
+        self.index_name = node.index.name
+        self.vector_store_type = node.index.type
+        self.feat_column = node.index.feat_column
         self.limit_count = node.limit_count
         self.search_query_expr = node.search_query_expr
 
     def exec(self, *args, **kwargs) -> Iterator[Batch]:
-        if self.node.vector_store_type == VectorStoreFactory.PGVECTOR:
-            self._native_vector_index_scan()
+        if self.vector_store_type == VectorStoreType.PGVECTOR:
+            return self._native_vector_index_scan()
         else:
-            self._evadb_vector_index_scan(*args, **kwargs)
+            return self._evadb_vector_index_scan(*args, **kwargs)
 
 
     def _get_search_query_results(self):
@@ -70,10 +76,19 @@ class VectorIndexScanExecutor(AbstractExecutor):
 
     def _native_vector_index_scan(self):
         search_feat = self._get_search_query_results()
-        search_feat = search_feat.reshape(-1)
+        search_feat = search_feat.reshape(-1).tolist()
 
-        # TODO: we need to access the Postgres handler here, but some parameters are only stored in children.
-
+        tb_catalog_entry = list(self.node.find_all(StoragePlan))[0].table
+        db_catalog_entry = self.db.catalog().get_database_catalog_entry(tb_catalog_entry.database_name)
+        with get_database_handler(db_catalog_entry.engine, **db_catalog_entry.params) as handler:
+            resp = handler.execute_native_query(f"""SELECT * FROM {tb_catalog_entry.name} 
+                                                ORDER BY {self.feat_column.name} <-> '{search_feat}' 
+                                                LIMIT {self.limit_count}""")
+            if resp.error is not None:
+                raise ExecutorError(f"Native index can encounters {resp.error}")
+            res = Batch(frames=resp.data)
+            res.modify_column_alias(tb_catalog_entry.name)
+            yield res
 
     def _evadb_vector_index_scan(self, *args, **kwargs):
         # Fetch the index from disk.
@@ -82,9 +97,9 @@ class VectorIndexScanExecutor(AbstractExecutor):
         )
         self.index_path = index_catalog_entry.save_file_path
         self.index = VectorStoreFactory.init_vector_store(
-            self.node.vector_store_type,
+            self.vector_store_type,
             self.index_name,
-            **handle_vector_store_params(self.node.vector_store_type, self.index_path),
+            **handle_vector_store_params(self.vector_store_type, self.index_path),
         )
 
         search_feat = self._get_search_query_results()

--- a/evadb/optimizer/operators.py
+++ b/evadb/optimizer/operators.py
@@ -22,6 +22,7 @@ from evadb.catalog.models.column_catalog import ColumnCatalogEntry
 from evadb.catalog.models.function_io_catalog import FunctionIOCatalogEntry
 from evadb.catalog.models.function_metadata_catalog import FunctionMetadataCatalogEntry
 from evadb.catalog.models.table_catalog import TableCatalogEntry
+from evadb.catalog.models.utils import IndexCatalogEntry
 from evadb.expression.abstract_expression import AbstractExpression
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.function_expression import FunctionExpression
@@ -29,7 +30,6 @@ from evadb.parser.alias import Alias
 from evadb.parser.create_statement import ColumnDefinition
 from evadb.parser.table_ref import TableInfo, TableRef
 from evadb.parser.types import JoinType, ObjectType, ShowType
-from evadb.catalog.models.utils import IndexCatalogEntry
 
 
 class OperatorType(IntEnum):

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -47,6 +47,8 @@ from evadb.plan_nodes.nested_loop_join_plan import NestedLoopJoinPlan
 from evadb.plan_nodes.predicate_plan import PredicatePlan
 from evadb.plan_nodes.project_plan import ProjectPlan
 from evadb.plan_nodes.show_info_plan import ShowInfoPlan
+from evadb.catalog.models.utils import IndexCatalogEntry
+from evadb.catalog.catalog_type import VectorStoreType
 
 if TYPE_CHECKING:
     from evadb.optimizer.optimizer_context import OptimizerContext
@@ -551,6 +553,11 @@ class CombineSimilarityOrderByAndLimitToVectorIndexScan(Rule):
         if not func_orderby_expr or func_orderby_expr.name != "Similarity":
             return
 
+        # Traverse to the LogicalGet operator.
+        tb_catalog_entry = list(sub_tree_root.opr.find_all(LogicalGet))[0].table_obj
+        db_catalog_entry = catalog_manager().get_database_catalog_entry(tb_catalog_entry.database_name)
+        is_postgres_data_source = db_catalog_entry is not None and db_catalog_entry.engine == "postgres"
+
         # Check if there exists an index on table and column.
         query_func_expr, base_func_expr = func_orderby_expr.children
 
@@ -561,26 +568,34 @@ class CombineSimilarityOrderByAndLimitToVectorIndexScan(Rule):
 
         # Get column catalog entry and function_signature.
         column_catalog_entry = tv_expr.col_object
-        function_signature = (
-            None
-            if isinstance(base_func_expr, TupleValueExpression)
-            else base_func_expr.signature()
-        )
 
-        # Get index catalog. Check if an index exists for matching
-        # function signature and table columns.
-        index_catalog_entry = (
-            catalog_manager().get_index_catalog_entry_by_column_and_function_signature(
-                column_catalog_entry, function_signature
+        # Only check the index existence when building on EvaDB data.
+        if not is_postgres_data_source:
+
+            # Get function_signature.
+            function_signature = (
+                None
+                if isinstance(base_func_expr, TupleValueExpression)
+                else base_func_expr.signature()
             )
-        )
-        if not index_catalog_entry:
-            return
+
+            # Get index catalog. Check if an index exists for matching
+            # function signature and table columns.
+            index_catalog_entry = (
+                catalog_manager().get_index_catalog_entry_by_column_and_function_signature(
+                    column_catalog_entry, function_signature
+                )
+            )
+            if not index_catalog_entry:
+                return
+        else:
+            index_catalog_entry = IndexCatalogEntry(
+                name="", save_file_path="", type=VectorStoreType.PGVECTOR, feat_column=column_catalog_entry,
+            )
 
         # Construct the Vector index scan plan.
         vector_index_scan_node = LogicalVectorIndexScan(
-            index_catalog_entry.name,
-            index_catalog_entry.type,
+            index_catalog_entry,
             limit_node.limit_count,
             query_func_expr,
         )
@@ -1263,8 +1278,7 @@ class LogicalVectorIndexScanToPhysical(Rule):
 
     def apply(self, before: LogicalVectorIndexScan, context: OptimizerContext):
         after = VectorIndexScanPlan(
-            before.index_name,
-            before.vector_store_type,
+            before.index,
             before.limit_count,
             before.search_query_expr,
         )

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from evadb.catalog.catalog_type import TableType, VectorStoreType
+from evadb.catalog.catalog_type import TableType
 from evadb.catalog.catalog_utils import is_video_table
 from evadb.constants import CACHEABLE_FUNCTIONS
 from evadb.executor.execution_context import Context

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from evadb.catalog.catalog_type import TableType
+from evadb.catalog.catalog_type import TableType, VectorStoreType
 from evadb.catalog.catalog_utils import is_video_table
 from evadb.constants import CACHEABLE_FUNCTIONS
 from evadb.executor.execution_context import Context

--- a/evadb/parser/evadb.lark
+++ b/evadb/parser/evadb.lark
@@ -53,7 +53,7 @@ function_metadata_key: uid
 
 function_metadata_value: string_literal | decimal_literal
 
-vector_store_type: USING (FAISS | QDRANT | PINECONE)
+vector_store_type: USING (FAISS | QDRANT | PINECONE | PGVECTOR )
 
 index_elem: ("(" uid_list ")"
           | "(" function_call ")")
@@ -412,10 +412,10 @@ DOCUMENT:             "DOCUMENT"i
 PDF:                  "PDF"i
 
 // Index types
-HNSW:                                "HNSW"i
 FAISS:                               "FAISS"i
 QDRANT:                              "QDRANT"i
 PINECONE:                            "PINECONE"i
+PGVECTOR:                            "PGVECTOR"i
 
 // Computer vision tasks
 

--- a/evadb/parser/lark_visitor/__init__.py
+++ b/evadb/parser/lark_visitor/__init__.py
@@ -17,7 +17,11 @@ from typing import List, TypeVar
 from lark import Tree, visitors
 
 from evadb.parser.lark_visitor._common_clauses_ids import CommonClauses
-from evadb.parser.lark_visitor._create_statements import CreateDatabase, CreateTable
+from evadb.parser.lark_visitor._create_statements import (
+    CreateDatabase,
+    CreateIndex,
+    CreateTable,
+)
 from evadb.parser.lark_visitor._delete_statement import Delete
 from evadb.parser.lark_visitor._drop_statement import DropObject
 from evadb.parser.lark_visitor._explain_statement import Explain
@@ -59,6 +63,7 @@ class LarkInterpreter(
     LarkBaseInterpreter,
     CommonClauses,
     CreateTable,
+    CreateIndex,
     CreateDatabase,
     Expressions,
     Functions,

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -232,19 +232,9 @@ class CreateTable:
         dimensions = self.dimension_helper(tree)
         return dimensions
 
-    def vector_store_type(self, tree):
-        vector_store_type = None
-        token = tree.children[1]
 
-        if str.upper(token) == "FAISS":
-            vector_store_type = VectorStoreType.FAISS
-        elif str.upper(token) == "QDRANT":
-            vector_store_type = VectorStoreType.QDRANT
-        elif str.upper(token) == "PINECONE":
-            vector_store_type = VectorStoreType.PINECONE
-        return vector_store_type
-
-    # INDEX CREATION
+# INDEX CREATION
+class CreateIndex:
     def create_index(self, tree):
         index_name = None
         if_not_exists = False
@@ -283,6 +273,20 @@ class CreateTable:
         return CreateIndexStatement(
             index_name, if_not_exists, table_ref, col_list, vector_store_type, function
         )
+
+    def vector_store_type(self, tree):
+        vector_store_type = None
+        token = tree.children[1]
+
+        if str.upper(token) == "FAISS":
+            vector_store_type = VectorStoreType.FAISS
+        elif str.upper(token) == "QDRANT":
+            vector_store_type = VectorStoreType.QDRANT
+        elif str.upper(token) == "PINECONE":
+            vector_store_type = VectorStoreType.PINECONE
+        elif str.upper(token) == "PGVECTOR":
+            vector_store_type = VectorStoreType.PGVECTOR
+        return vector_store_type
 
 
 class CreateDatabase:

--- a/evadb/plan_nodes/abstract_plan.py
+++ b/evadb/plan_nodes/abstract_plan.py
@@ -126,5 +126,5 @@ class AbstractPlan(ABC):
         """
 
         for node in self.bfs():
-            if isinstance(node, plan_type):
+            if isinstance(node, plan_type) or self.opr_type == plan_type:
                 yield node

--- a/evadb/plan_nodes/vector_index_scan_plan.py
+++ b/evadb/plan_nodes/vector_index_scan_plan.py
@@ -12,11 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from evadb.catalog.catalog_type import VectorStoreType
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.function_expression import FunctionExpression
 from evadb.plan_nodes.abstract_plan import AbstractPlan
 from evadb.plan_nodes.types import PlanOprType
+from evadb.catalog.models.utils import IndexCatalogEntry
 
 
 class VectorIndexScanPlan(AbstractPlan):
@@ -33,24 +33,18 @@ class VectorIndexScanPlan(AbstractPlan):
 
     def __init__(
         self,
-        index_name: str,
-        vector_store_type: VectorStoreType,
+        index: IndexCatalogEntry,
         limit_count: ConstantValueExpression,
         search_query_expr: FunctionExpression,
     ):
         super().__init__(PlanOprType.VECTOR_INDEX_SCAN)
-        self._index_name = index_name
-        self._vector_store_type = vector_store_type
+        self._index = index
         self._limit_count = limit_count
         self._search_query_expr = search_query_expr
 
     @property
-    def index_name(self):
-        return self._index_name
-
-    @property
-    def vector_store_type(self):
-        return self._vector_store_type
+    def index(self):
+        return self._index
 
     @property
     def limit_count(self):
@@ -62,8 +56,8 @@ class VectorIndexScanPlan(AbstractPlan):
 
     def __str__(self):
         return "VectorIndexScan(index_name={}, vector_store_type={}, limit_count={}, search_query_expr={})".format(
-            self._index_name,
-            self.vector_store_type,
+            self._index.name,
+            self._index.vector_store_type,
             self._limit_count,
             self._search_query_expr,
         )
@@ -72,8 +66,7 @@ class VectorIndexScanPlan(AbstractPlan):
         return hash(
             (
                 super().__hash__(),
-                self.index_name,
-                self.vector_store_type,
+                self.index,
                 self.limit_count,
                 self.search_query_expr,
             )

--- a/evadb/plan_nodes/vector_index_scan_plan.py
+++ b/evadb/plan_nodes/vector_index_scan_plan.py
@@ -12,11 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from evadb.catalog.models.utils import IndexCatalogEntry
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.function_expression import FunctionExpression
 from evadb.plan_nodes.abstract_plan import AbstractPlan
 from evadb.plan_nodes.types import PlanOprType
-from evadb.catalog.models.utils import IndexCatalogEntry
 
 
 class VectorIndexScanPlan(AbstractPlan):

--- a/evadb/third_party/databases/postgres/postgres_handler.py
+++ b/evadb/third_party/databases/postgres/postgres_handler.py
@@ -177,7 +177,6 @@ class PostgresHandler(DBHandler):
             # Handle user defined types constructed by Postgres extension.
         }
 
-        print("Type conversion", pg_type, udt_name)
         if pg_type in primitive_type_mapping:
             return primitive_type_mapping[pg_type]
         elif pg_type == "USER-DEFINED" and udt_name in user_defined_type_mapping:

--- a/test/third_party_tests/test_native_create_index.py
+++ b/test/third_party_tests/test_native_create_index.py
@@ -13,20 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from pathlib import Path
-from test.markers import macos_skip_marker
-from test.util import get_evadb_for_testing, load_functions_for_testing
+from test.util import get_evadb_for_testing
 
-import numpy as np
-import pandas as pd
 import pytest
 
-from evadb.catalog.catalog_type import VectorStoreType
-from evadb.executor.executor_utils import ExecutorError
-from evadb.models.storage.batch import Batch
 from evadb.server.command_handler import execute_query_fetch_all
-from evadb.storage.storage_engine import StorageEngine
-from evadb.utils.generic_utils import try_to_import_faiss
 
 
 @pytest.mark.notparallel
@@ -57,9 +48,9 @@ class CreateIndexTest(unittest.TestCase):
 
         # Insert data.
         vector_list = [
-            [0,0,0],
-            [1,1,1],
-            [2,2,2],
+            [0, 0, 0],
+            [1, 1, 1],
+            [2, 2, 2],
         ]
         for vector in vector_list:
             query = f"""USE test_data_source {{
@@ -68,7 +59,7 @@ class CreateIndexTest(unittest.TestCase):
             execute_query_fetch_all(self.evadb, query)
 
         # Create index.
-        query = """CREATE INDEX test_index 
+        query = """CREATE INDEX test_index
             ON test_data_source.test_vector (embedding)
             USING PGVECTOR"""
         execute_query_fetch_all(self.evadb, query)
@@ -82,7 +73,7 @@ class CreateIndexTest(unittest.TestCase):
         self.assertEqual(len(df), 1)
         self.assertEqual(df["indexname"][0], "test_index")
         self.assertEqual(
-            df["indexdef"][0], 
+            df["indexdef"][0],
             """CREATE INDEX test_index ON public.test_vector USING hnsw (embedding vector_l2_ops)""",
         )
 

--- a/test/third_party_tests/test_native_create_index.py
+++ b/test/third_party_tests/test_native_create_index.py
@@ -1,0 +1,93 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from pathlib import Path
+from test.markers import macos_skip_marker
+from test.util import get_evadb_for_testing, load_functions_for_testing
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from evadb.catalog.catalog_type import VectorStoreType
+from evadb.executor.executor_utils import ExecutorError
+from evadb.models.storage.batch import Batch
+from evadb.server.command_handler import execute_query_fetch_all
+from evadb.storage.storage_engine import StorageEngine
+from evadb.utils.generic_utils import try_to_import_faiss
+
+
+@pytest.mark.notparallel
+class CreateIndexTest(unittest.TestCase):
+    def setUp(self):
+        self.evadb = get_evadb_for_testing()
+        self.evadb.catalog().reset()
+
+    def test_native_engine_should_create_index(self):
+        # Create database.
+        params = {
+            "user": "eva",
+            "password": "password",
+            "host": "localhost",
+            "port": "5432",
+            "database": "evadb",
+        }
+        query = f"""CREATE DATABASE test_data_source
+                    WITH ENGINE = "postgres",
+                    PARAMETERS = {params};"""
+        execute_query_fetch_all(self.evadb, query)
+
+        # Create table.
+        query = """USE test_data_source {
+            CREATE TABLE test_vector (embedding vector(3))
+        }"""
+        execute_query_fetch_all(self.evadb, query)
+
+        # Insert data.
+        vector_list = [
+            [0,0,0],
+            [1,1,1],
+            [2,2,2],
+        ]
+        for vector in vector_list:
+            query = f"""USE test_data_source {{
+                INSERT INTO test_vector (embedding) VALUES ('{vector}')
+            }}"""
+            execute_query_fetch_all(self.evadb, query)
+
+        # Create index.
+        query = """CREATE INDEX test_index 
+            ON test_data_source.test_vector (embedding)
+            USING PGVECTOR"""
+        execute_query_fetch_all(self.evadb, query)
+
+        # Check the existence of index.
+        query = """USE test_data_source {
+            SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'test_vector'
+        }"""
+        df = execute_query_fetch_all(self.evadb, query).frames
+
+        self.assertEqual(len(df), 1)
+        self.assertEqual(df["indexname"][0], "test_index")
+        self.assertEqual(
+            df["indexdef"][0], 
+            """CREATE INDEX test_index ON public.test_vector USING hnsw (embedding vector_l2_ops)""",
+        )
+
+        # Clean up.
+        query = "USE test_data_source { DROP INDEX test_index }"
+        execute_query_fetch_all(self.evadb, query)
+        query = "USE test_data_source { DROP TABLE test_vector }"
+        execute_query_fetch_all(self.evadb, query)

--- a/test/third_party_tests/test_native_similarity_index.py
+++ b/test/third_party_tests/test_native_similarity_index.py
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import get_evadb_for_testing
+from test.util import (
+    create_sample_image,
+    get_evadb_for_testing,
+    load_functions_for_testing,
+)
 
 import pytest
 
 from evadb.server.command_handler import execute_query_fetch_all
-from test.util import create_sample_image, load_functions_for_testing
 
 
 @pytest.mark.notparallel
@@ -87,8 +90,8 @@ class CreateIndexTest(unittest.TestCase):
         )
 
         # Check the index scan plan.
-        query = f"""SELECT idx, embedding FROM test_data_source.test_vector 
-            ORDER BY Similarity(DummyFeatureExtractor(Open('{self.img_path}')), embedding) 
+        query = f"""SELECT idx, embedding FROM test_data_source.test_vector
+            ORDER BY Similarity(DummyFeatureExtractor(Open('{self.img_path}')), embedding)
             LIMIT 1"""
         df = execute_query_fetch_all(self.evadb, f"EXPLAIN {query}").frames
         self.assertIn("VectorIndexScan", df[0][0])

--- a/test/third_party_tests/test_native_similarity_index.py
+++ b/test/third_party_tests/test_native_similarity_index.py
@@ -26,7 +26,7 @@ from evadb.server.command_handler import execute_query_fetch_all
 
 @pytest.mark.notparallel
 class CreateIndexTest(unittest.TestCase):
-    def setUp(self):
+    def setUpClass(self):
         self.evadb = get_evadb_for_testing()
         self.evadb.catalog().reset()
 
@@ -36,7 +36,6 @@ class CreateIndexTest(unittest.TestCase):
         # Load functions.
         load_functions_for_testing(self.evadb, mode="debug")
 
-    def test_native_engine_should_create_index(self):
         # Create database.
         params = {
             "user": "eva",
@@ -50,6 +49,14 @@ class CreateIndexTest(unittest.TestCase):
                     PARAMETERS = {params};"""
         execute_query_fetch_all(self.evadb, query)
 
+    def tearDownClass(self):
+        # Clean up.
+        query = "USE test_data_source { DROP INDEX test_index }"
+        execute_query_fetch_all(self.evadb, query)
+        query = "USE test_data_source { DROP TABLE test_vector }"
+        execute_query_fetch_all(self.evadb, query)
+
+    def test_native_engine_should_create_index(self):
         # Create table.
         query = """USE test_data_source {
             CREATE TABLE test_vector (idx INTEGER, dummy INTEGER, embedding vector(27))
@@ -100,9 +107,3 @@ class CreateIndexTest(unittest.TestCase):
         df = execute_query_fetch_all(self.evadb, query).frames
         self.assertEqual(df["test_vector.idx"][0], 0)
         self.assertNotIn("test_vector.dummy", df.columns)
-
-        # Clean up.
-        query = "USE test_data_source { DROP INDEX test_index }"
-        execute_query_fetch_all(self.evadb, query)
-        query = "USE test_data_source { DROP TABLE test_vector }"
-        execute_query_fetch_all(self.evadb, query)

--- a/test/third_party_tests/test_native_similarity_index.py
+++ b/test/third_party_tests/test_native_similarity_index.py
@@ -26,15 +26,16 @@ from evadb.server.command_handler import execute_query_fetch_all
 
 @pytest.mark.notparallel
 class CreateIndexTest(unittest.TestCase):
-    def setUpClass(self):
-        self.evadb = get_evadb_for_testing()
-        self.evadb.catalog().reset()
+    @classmethod
+    def setUpClass(cls):
+        cls.evadb = get_evadb_for_testing()
+        cls.evadb.catalog().reset()
 
         # Get sample image.
-        self.img_path = create_sample_image()
+        cls.img_path = create_sample_image()
 
         # Load functions.
-        load_functions_for_testing(self.evadb, mode="debug")
+        load_functions_for_testing(cls.evadb, mode="debug")
 
         # Create database.
         params = {
@@ -47,14 +48,15 @@ class CreateIndexTest(unittest.TestCase):
         query = f"""CREATE DATABASE test_data_source
                     WITH ENGINE = "postgres",
                     PARAMETERS = {params};"""
-        execute_query_fetch_all(self.evadb, query)
+        execute_query_fetch_all(cls.evadb, query)
 
-    def tearDownClass(self):
+    @classmethod
+    def tearDownClass(cls):
         # Clean up.
         query = "USE test_data_source { DROP INDEX test_index }"
-        execute_query_fetch_all(self.evadb, query)
+        execute_query_fetch_all(cls.evadb, query)
         query = "USE test_data_source { DROP TABLE test_vector }"
-        execute_query_fetch_all(self.evadb, query)
+        execute_query_fetch_all(cls.evadb, query)
 
     def test_native_engine_should_create_index(self):
         # Create table.


### PR DESCRIPTION
I will need some feedback on the design here. @xzdandy @gaurav274 

This PR reflects my initial design for in-database index features like pgvector. My initial idea is to offload as much as possible to the native database. When we create an index and do the index scan, we simply push an emulated query to the underlying database. While this is doable, this will introduce separate implementation paths in different components including the optimizer and the executor. 
 
Other than the current design, another option is to reuse the third-party vector integration interface. There are also a few details that I am not clear about
* For other vector libraries, we keep an index entry in our own catalog. Do we still maintain that even for pgvector? In the original implementation, the index catalog entry is linked to a table catalog entry. Because in this case, the table is inside Postgres, we also need to change the implementation here a little bit.
* ~~(Issue related to performance). Following the current create index implementation, data will be fetched from Postgres first but it is not really needed. The create index will anyway run inside Postgres.~~
* ~~The current vector index scan is implemented based on `_row_id`. When it is scanning data from Postgres, we need to figure out a way to populate `_row_id` for the native database engine.~~