### PR TITLE
fix: release change log

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          fetch-depth: 0
+      - name: Switch to master
+        run: git checkout master
       - name: Install env.
         run: |
           python -m venv test_evadb

--- a/script/releasing/releaser.py
+++ b/script/releasing/releaser.py
@@ -174,7 +174,7 @@ def release_version(current_version):
     run_command(f"git push origin release-{NEXT_RELEASE}")
 
 
-def get_commit_id_of_latest_release(release_index=0):
+def get_commit_id_of_latest_release():
     # Default to the latest release.
     import requests
 
@@ -183,7 +183,7 @@ def get_commit_id_of_latest_release(release_index=0):
     response = requests.get(url)
     data = response.json()
 
-    latest_release = data[release_index]
+    latest_release = data[0]
     release_date = latest_release["created_at"]
 
     return release_date
@@ -416,9 +416,7 @@ if __name__ == "__main__":
         publish_wheels(current_version_str_without_dev)
 
     if args.upload_assets:
-        # We assume that we run each command sequentially here. When a new release
-        # is made, the change log needs to be based on the second latest release.
-        release_date = get_commit_id_of_latest_release(release_index=1)
+        release_date = get_commit_id_of_latest_release()
         changelog = get_changelog(release_date)
         upload_assets(changelog, current_version_str_without_dev)
 
@@ -455,3 +453,4 @@ if __name__ == "__main__":
 
         # BUMP UP VERSION
         bump_up_version(next_version)
+


### PR DESCRIPTION
* Roll back my previous changes. The previous code is correct. The release URL is not updated until we upload assets, so it should affect things.
* The root cause is the checkout action used by github tries to optimize and does not pull histories of commits besides the head. Consequently, our script cannot get changelog from the git histories. 