### PR TITLE
Skip pinecone test if pinecone is not installed

### DIFF
--- a/evadb/utils/generic_utils.py
+++ b/evadb/utils/generic_utils.py
@@ -507,6 +507,14 @@ def is_qdrant_available() -> bool:
         return False
 
 
+def is_pinecone_available() -> bool:
+    try:
+        try_to_import_pinecone_client()
+        return True
+    except ValueError:  # noqa: E722
+        return False
+
+
 ##############################
 ## UTILS
 ##############################

--- a/test/integration_tests/long/test_similarity.py
+++ b/test/integration_tests/long/test_similarity.py
@@ -15,7 +15,7 @@
 import os
 import time
 import unittest
-from test.markers import qdrant_skip_marker
+from test.markers import pinecone_skip_marker, qdrant_skip_marker
 from test.util import (
     create_sample_image,
     get_evadb_for_testing,
@@ -411,6 +411,7 @@ class SimilarityTests(unittest.TestCase):
         # Cleanup
         self.evadb.catalog().drop_index_catalog_entry("testQdrantIndexImageDataset")
 
+    @pinecone_skip_marker
     def test_end_to_end_index_scan_should_work_correctly_on_image_dataset_pinecone(
         self,
     ):

--- a/test/markers.py
+++ b/test/markers.py
@@ -22,6 +22,7 @@ from evadb.utils.generic_utils import (
     is_forecast_available,
     is_gpu_available,
     is_ludwig_available,
+    is_pinecone_available,
     is_qdrant_available,
 )
 
@@ -32,6 +33,11 @@ asyncio_skip_marker = pytest.mark.skipif(
 qdrant_skip_marker = pytest.mark.skipif(
     is_qdrant_available() is False,
     reason="qdrant requires grcpio which is broken on 3.11",
+)
+
+pinecone_skip_marker = pytest.mark.skipif(
+    is_pinecone_available() is False,
+    reason="skipping since pinecone is not installed",
 )
 
 windows_skip_marker = pytest.mark.skipif(


### PR DESCRIPTION
The integration test currently fails if pinecone is not installed. Added a skip marker for the same.