### PR TITLE
Fix staging CI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,7 @@ jobs:
             if [[ $PY_VERSION = "3.10" ]] || [[ $PY_VERSION = "3.11" ]]; then
               export SETUPTOOLS_USE_DISTUTILS=stdlib
             fi
+            set +e # To make sure the later cache step is not skipped.
             bash script/test/test.sh -m "<< parameters.mode >>"
 
       # Enable cache save conditionally (to avoid empty cache in Notebooks)

--- a/test/integration_tests/long/test_similarity.py
+++ b/test/integration_tests/long/test_similarity.py
@@ -463,6 +463,7 @@ class SimilarityTests(unittest.TestCase):
             drop_query = "DROP INDEX testChromaDBIndexImageDataset"
             execute_query_fetch_all(self.evadb, drop_query)
 
+    @pytest.mark.skip(reason="require pinecone")
     @pinecone_skip_marker
     def test_end_to_end_index_scan_should_work_correctly_on_image_dataset_pinecone(
         self,

--- a/test/util.py
+++ b/test/util.py
@@ -17,6 +17,7 @@ import multiprocessing as mp
 import os
 import shutil
 import socket
+import time
 from contextlib import closing
 from itertools import repeat
 from multiprocessing import Pool
@@ -713,5 +714,6 @@ class DummyLLM(AbstractFunction):
             results.append(("" if prompt is None else prompt) + query + " " + content)
 
         df = pd.DataFrame({"response": results})
-
+        # Make it slower
+        time.sleep(1)
         return df


### PR DESCRIPTION
- [x] add `time.sleep` in `DummyLLM` to make it run longer for the resue test cases.
- [x] always cache even the test is failed. 
- [x] skip pinecone tests due to free-tier limit.  