### PR TITLE
feat: create index from projection

### DIFF
--- a/evadb/binder/binder_utils.py
+++ b/evadb/binder/binder_utils.py
@@ -42,6 +42,7 @@ from evadb.parser.create_statement import ColumnDefinition
 from evadb.parser.table_ref import TableInfo, TableRef
 from evadb.third_party.databases.interface import get_database_handler
 from evadb.utils.logging_manager import logger
+from evadb.catalog.sql_config import ROW_NUM_COLUMN
 
 
 class BinderError(Exception):
@@ -169,6 +170,14 @@ def extend_star(
         ]
     )
     return target_list
+
+
+def create_row_num_tv_expr(table_alias):
+    tv_expr = TupleValueExpression(name=ROW_NUM_COLUMN)
+    tv_expr.table_alias = table_alias
+    tv_expr.col_alias = f"{table_alias}.{ROW_NUM_COLUMN.lower()}"
+    tv_expr.col_object = ColumnCatalogEntry(name=ROW_NUM_COLUMN, type=ColumnType.INTEGER)
+    return tv_expr
 
 
 def check_groupby_pattern(table_ref: TableRef, groupby_string: str) -> None:

--- a/evadb/binder/binder_utils.py
+++ b/evadb/binder/binder_utils.py
@@ -34,6 +34,8 @@ from evadb.catalog.sql_config import IDENTIFIER_COLUMN
 if TYPE_CHECKING:
     from evadb.binder.statement_binder_context import StatementBinderContext
     from evadb.catalog.catalog_manager import CatalogManager
+
+from evadb.catalog.sql_config import ROW_NUM_COLUMN
 from evadb.expression.abstract_expression import AbstractExpression, ExpressionType
 from evadb.expression.function_expression import FunctionExpression
 from evadb.expression.tuple_value_expression import TupleValueExpression
@@ -42,7 +44,6 @@ from evadb.parser.create_statement import ColumnDefinition
 from evadb.parser.table_ref import TableInfo, TableRef
 from evadb.third_party.databases.interface import get_database_handler
 from evadb.utils.logging_manager import logger
-from evadb.catalog.sql_config import ROW_NUM_COLUMN
 
 
 class BinderError(Exception):
@@ -176,7 +177,9 @@ def create_row_num_tv_expr(table_alias):
     tv_expr = TupleValueExpression(name=ROW_NUM_COLUMN)
     tv_expr.table_alias = table_alias
     tv_expr.col_alias = f"{table_alias}.{ROW_NUM_COLUMN.lower()}"
-    tv_expr.col_object = ColumnCatalogEntry(name=ROW_NUM_COLUMN, type=ColumnType.INTEGER)
+    tv_expr.col_object = ColumnCatalogEntry(
+        name=ROW_NUM_COLUMN, type=ColumnType.INTEGER
+    )
     return tv_expr
 
 

--- a/evadb/binder/create_index_statement_binder.py
+++ b/evadb/binder/create_index_statement_binder.py
@@ -12,14 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from evadb.binder.binder_utils import BinderError
+from evadb.binder.binder_utils import BinderError, create_row_num_tv_expr, extend_star
 from evadb.binder.statement_binder import StatementBinder
 from evadb.catalog.catalog_type import NdArrayType, VectorStoreType
+from evadb.expression.function_expression import FunctionExpression
+from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.parser.create_index_statement import CreateIndexStatement
 from evadb.third_party.databases.interface import get_database_handler
-from evadb.expression.tuple_value_expression import TupleValueExpression
-from evadb.expression.function_expression import FunctionExpression
-from evadb.binder.binder_utils import extend_star, create_row_num_tv_expr
 
 
 def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
@@ -33,7 +32,7 @@ def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
         if isinstance(project_expr, TupleValueExpression) and project_expr.name == "*":
             project_expr_list += extend_star(binder._binder_context)
         elif isinstance(project_expr, FunctionExpression):
-            func_project_expr = project_expr 
+            func_project_expr = project_expr
             project_expr_list += [project_expr]
 
     # Bind all projection expressions.

--- a/evadb/binder/create_index_statement_binder.py
+++ b/evadb/binder/create_index_statement_binder.py
@@ -17,12 +17,32 @@ from evadb.binder.statement_binder import StatementBinder
 from evadb.catalog.catalog_type import NdArrayType, VectorStoreType
 from evadb.parser.create_index_statement import CreateIndexStatement
 from evadb.third_party.databases.interface import get_database_handler
+from evadb.expression.tuple_value_expression import TupleValueExpression
+from evadb.expression.function_expression import FunctionExpression
+from evadb.binder.binder_utils import extend_star, create_row_num_tv_expr
 
 
 def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
     binder.bind(node.table_ref)
-    if node.function:
-        binder.bind(node.function)
+
+    func_project_expr = None
+
+    # Extend projection list.
+    project_expr_list = []
+    for project_expr in node.project_expr_list:
+        if isinstance(project_expr, TupleValueExpression) and project_expr.name == "*":
+            project_expr_list += extend_star(binder._binder_context)
+        elif isinstance(project_expr, FunctionExpression):
+            func_project_expr = project_expr 
+            project_expr_list += [project_expr]
+
+    # Bind all projection expressions.
+    node.project_expr_list = project_expr_list
+    for project_expr in node.project_expr_list:
+        binder.bind(project_expr)
+
+    # Append ROW_NUM_COLUMN.
+    node.project_expr_list += [create_row_num_tv_expr(node.table_ref.alias)]
 
     # TODO: create index currently only supports single numpy column.
     assert len(node.col_list) == 1, "Index cannot be created on more than 1 column"
@@ -54,13 +74,14 @@ def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
         # underlying native storage engine.
         return
 
-    if not node.function:
-        # Feature table type needs to be float32 numpy array.
-        assert (
-            len(node.col_list) == 1
-        ), f"Index can be only created on one column, but instead {len(node.col_list)} are provided"
-        col_def = node.col_list[0]
+    # Index can be only created on single column.
+    assert (
+        len(node.col_list) == 1
+    ), f"Index can be only created on one column, but instead {len(node.col_list)} are provided"
+    col_def = node.col_list[0]
 
+    if func_project_expr is None:
+        # Feature table type needs to be float32 numpy array.
         table_ref_obj = node.table_ref.table.table_obj
         col_list = [col for col in table_ref_obj.columns if col.name == col_def.name]
         assert (
@@ -78,7 +99,7 @@ def bind_create_index(binder: StatementBinder, node: CreateIndexStatement):
     else:
         # Output of the function should be 2 dimension and float32 type.
         function_obj = binder._catalog().get_function_catalog_entry_by_name(
-            node.function.name
+            func_project_expr.name
         )
         for output in function_obj.outputs:
             assert (

--- a/evadb/binder/statement_binder.py
+++ b/evadb/binder/statement_binder.py
@@ -30,7 +30,7 @@ from evadb.binder.binder_utils import (
     resolve_alias_table_value_expression,
 )
 from evadb.binder.statement_binder_context import StatementBinderContext
-from evadb.catalog.catalog_type import ColumnType, TableType, VideoColumnName
+from evadb.catalog.catalog_type import ColumnType, TableType
 from evadb.catalog.catalog_utils import get_metadata_properties, is_document_table
 from evadb.configuration.constants import EvaDB_INSTALLATION_DIR
 from evadb.expression.abstract_expression import AbstractExpression, ExpressionType
@@ -258,16 +258,9 @@ class StatementBinder:
 
     @bind.register(TupleValueExpression)
     def _bind_tuple_expr(self, node: TupleValueExpression):
-        table_alias, col_obj = self._binder_context.get_binded_column(
-            node.name, node.table_alias
-        )
-        node.table_alias = table_alias
-        if node.name == VideoColumnName.audio:
-            self._binder_context.enable_audio_retrieval()
-        if node.name == VideoColumnName.data:
-            self._binder_context.enable_video_retrieval()
-        node.col_alias = "{}.{}".format(table_alias, node.name.lower())
-        node.col_object = col_obj
+        from evadb.binder.tuple_value_expression_binder import bind_tuple_expr
+
+        bind_tuple_expr(self, node)
 
     @bind.register(FunctionExpression)
     def _bind_func_expr(self, node: FunctionExpression):

--- a/evadb/binder/tuple_value_expression_binder.py
+++ b/evadb/binder/tuple_value_expression_binder.py
@@ -1,0 +1,16 @@
+from evadb.catalog.catalog_type import VideoColumnName
+from evadb.expression.tuple_value_expression import TupleValueExpression
+from evadb.binder.statement_binder import StatementBinder
+
+
+def bind_tuple_expr(binder: StatementBinder, node: TupleValueExpression):
+    table_alias, col_obj = binder._binder_context.get_binded_column(
+        node.name, node.table_alias
+    )
+    node.table_alias = table_alias
+    if node.name == VideoColumnName.audio:
+        binder._binder_context.enable_audio_retrieval()
+    if node.name == VideoColumnName.data:
+        binder._binder_context.enable_video_retrieval()
+    node.col_alias = "{}.{}".format(table_alias, node.name.lower())
+    node.col_object = col_obj

--- a/evadb/binder/tuple_value_expression_binder.py
+++ b/evadb/binder/tuple_value_expression_binder.py
@@ -1,6 +1,20 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from evadb.binder.statement_binder import StatementBinder
 from evadb.catalog.catalog_type import VideoColumnName
 from evadb.expression.tuple_value_expression import TupleValueExpression
-from evadb.binder.statement_binder import StatementBinder
 
 
 def bind_tuple_expr(binder: StatementBinder, node: TupleValueExpression):

--- a/evadb/catalog/catalog_manager.py
+++ b/evadb/catalog/catalog_manager.py
@@ -417,7 +417,12 @@ class CatalogManager(object):
         index_def: str,
     ) -> IndexCatalogEntry:
         index_catalog_entry = self._index_service.insert_entry(
-            name, save_file_path, vector_store_type, feat_column, function_signature, index_def,
+            name,
+            save_file_path,
+            vector_store_type,
+            feat_column,
+            function_signature,
+            index_def,
         )
         return index_catalog_entry
 

--- a/evadb/catalog/catalog_manager.py
+++ b/evadb/catalog/catalog_manager.py
@@ -414,9 +414,10 @@ class CatalogManager(object):
         vector_store_type: VectorStoreType,
         feat_column: ColumnCatalogEntry,
         function_signature: str,
+        index_def: str,
     ) -> IndexCatalogEntry:
         index_catalog_entry = self._index_service.insert_entry(
-            name, save_file_path, vector_store_type, feat_column, function_signature
+            name, save_file_path, vector_store_type, feat_column, function_signature, index_def,
         )
         return index_catalog_entry
 

--- a/evadb/catalog/models/index_catalog.py
+++ b/evadb/catalog/models/index_catalog.py
@@ -31,6 +31,8 @@ class IndexCatalog(BaseModel):
     `_feat_column_id:` the `_row_id` of the `ColumnCatalog` entry for the column on which the index is built.
     `_function_signature:` if the index is created by running function expression on input column, this will store
                       the function signature of the used function. Otherwise, this field is None.
+    `_index_def:` the original SQL statement that is used to create this index. We record this to rerun create index
+                on updated table.
     """
 
     __tablename__ = "index_catalog"

--- a/evadb/catalog/models/index_catalog.py
+++ b/evadb/catalog/models/index_catalog.py
@@ -42,6 +42,7 @@ class IndexCatalog(BaseModel):
         "column_id", Integer, ForeignKey("column_catalog._row_id", ondelete="CASCADE")
     )
     _function_signature = Column("function", String, default=None)
+    _index_def = Column("index_def", String, default=None)
 
     _feat_column = relationship(
         "ColumnCatalog",
@@ -55,12 +56,14 @@ class IndexCatalog(BaseModel):
         type: VectorStoreType,
         feat_column_id: int = None,
         function_signature: str = None,
+        index_def: str = None,
     ):
         self._name = name
         self._save_file_path = save_file_path
         self._type = type
         self._feat_column_id = feat_column_id
         self._function_signature = function_signature
+        self._index_def = index_def
 
     def as_dataclass(self) -> "IndexCatalogEntry":
         feat_column = self._feat_column.as_dataclass() if self._feat_column else None
@@ -71,5 +74,6 @@ class IndexCatalog(BaseModel):
             type=self._type,
             feat_column_id=self._feat_column_id,
             function_signature=self._function_signature,
+            index_def=self._index_def,
             feat_column=feat_column,
         )

--- a/evadb/catalog/models/utils.py
+++ b/evadb/catalog/models/utils.py
@@ -201,6 +201,7 @@ class IndexCatalogEntry:
     row_id: int = None
     feat_column_id: int = None
     function_signature: str = None
+    index_def: str = None
     feat_column: ColumnCatalogEntry = None
 
 

--- a/evadb/catalog/services/index_catalog_service.py
+++ b/evadb/catalog/services/index_catalog_service.py
@@ -35,9 +35,10 @@ class IndexCatalogService(BaseService):
         type: VectorStoreType,
         feat_column: ColumnCatalogEntry,
         function_signature: str,
+        index_def: str,
     ) -> IndexCatalogEntry:
         index_entry = IndexCatalog(
-            name, save_file_path, type, feat_column.row_id, function_signature
+            name, save_file_path, type, feat_column.row_id, function_signature, index_def,
         )
         index_entry = index_entry.save(self.session)
         return index_entry.as_dataclass()

--- a/evadb/catalog/services/index_catalog_service.py
+++ b/evadb/catalog/services/index_catalog_service.py
@@ -38,7 +38,12 @@ class IndexCatalogService(BaseService):
         index_def: str,
     ) -> IndexCatalogEntry:
         index_entry = IndexCatalog(
-            name, save_file_path, type, feat_column.row_id, function_signature, index_def,
+            name,
+            save_file_path,
+            type,
+            feat_column.row_id,
+            function_signature,
+            index_def,
         )
         index_entry = index_entry.save(self.session)
         return index_entry.as_dataclass()

--- a/evadb/executor/create_index_executor.py
+++ b/evadb/executor/create_index_executor.py
@@ -146,6 +146,7 @@ class CreateIndexExecutor(AbstractExecutor):
                 function_expression.signature()
                 if function_expression is not None
                 else None,
+                self.node.index_def,
             )
         except Exception as e:
             # Delete index.

--- a/evadb/executor/create_index_executor.py
+++ b/evadb/executor/create_index_executor.py
@@ -21,14 +21,13 @@ from evadb.catalog.sql_config import ROW_NUM_COLUMN
 from evadb.database import EvaDBDatabase
 from evadb.executor.abstract_executor import AbstractExecutor
 from evadb.executor.executor_utils import ExecutorError, handle_vector_store_params
+from evadb.expression.function_expression import FunctionExpression
 from evadb.models.storage.batch import Batch
 from evadb.plan_nodes.create_index_plan import CreateIndexPlan
-from evadb.storage.storage_engine import StorageEngine
 from evadb.third_party.databases.interface import get_database_handler
 from evadb.third_party.vector_stores.types import FeaturePayload
 from evadb.third_party.vector_stores.utils import VectorStoreFactory
 from evadb.utils.logging_manager import logger
-from evadb.expression.function_expression import FunctionExpression
 
 
 class CreateIndexExecutor(AbstractExecutor):
@@ -144,7 +143,9 @@ class CreateIndexExecutor(AbstractExecutor):
                 index_path,
                 self.node.vector_store_type,
                 feat_column,
-                function_expression.signature() if function_expression is not None else None,
+                function_expression.signature()
+                if function_expression is not None
+                else None,
             )
         except Exception as e:
             # Delete index.

--- a/evadb/optimizer/operators.py
+++ b/evadb/optimizer/operators.py
@@ -1084,7 +1084,8 @@ class LogicalCreateIndex(Operator):
         table_ref: TableRef,
         col_list: List[ColumnDefinition],
         vector_store_type: VectorStoreType,
-        project_expr_list: List[AbstractExpression] = None,
+        project_expr_list: List[AbstractExpression],
+        index_def: str,
         children: List = None,
     ):
         super().__init__(OperatorType.LOGICALCREATEINDEX, children)
@@ -1094,6 +1095,7 @@ class LogicalCreateIndex(Operator):
         self._col_list = col_list
         self._vector_store_type = vector_store_type
         self._project_expr_list = project_expr_list
+        self._index_def = index_def
 
     @property
     def name(self):
@@ -1119,6 +1121,10 @@ class LogicalCreateIndex(Operator):
     def project_expr_list(self):
         return self._project_expr_list
 
+    @property
+    def index_def(self):
+        return self._index_def
+
     def __eq__(self, other):
         is_subtree_equal = super().__eq__(other)
         if not isinstance(other, LogicalCreateIndex):
@@ -1131,6 +1137,7 @@ class LogicalCreateIndex(Operator):
             and self.col_list == other.col_list
             and self.vector_store_type == other.vector_store_type
             and self.project_expr_list == other.project_expr_list
+            and self.index_def == other.index_def
         )
 
     def __hash__(self) -> int:
@@ -1143,6 +1150,7 @@ class LogicalCreateIndex(Operator):
                 tuple(self.col_list),
                 self.vector_store_type,
                 tuple(self.project_expr_list),
+                self.index_def,
             )
         )
 

--- a/evadb/optimizer/operators.py
+++ b/evadb/optimizer/operators.py
@@ -15,7 +15,7 @@
 from collections import deque
 from enum import IntEnum, auto
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Union
 
 from evadb.catalog.catalog_type import VectorStoreType
 from evadb.catalog.models.column_catalog import ColumnCatalogEntry
@@ -26,6 +26,7 @@ from evadb.catalog.models.utils import IndexCatalogEntry
 from evadb.expression.abstract_expression import AbstractExpression
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.function_expression import FunctionExpression
+from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.parser.alias import Alias
 from evadb.parser.create_statement import ColumnDefinition
 from evadb.parser.table_ref import TableInfo, TableRef
@@ -1084,7 +1085,7 @@ class LogicalCreateIndex(Operator):
         table_ref: TableRef,
         col_list: List[ColumnDefinition],
         vector_store_type: VectorStoreType,
-        function: FunctionExpression = None,
+        project_expr_list: List[AbstractExpression] = None,
         children: List = None,
     ):
         super().__init__(OperatorType.LOGICALCREATEINDEX, children)
@@ -1093,7 +1094,7 @@ class LogicalCreateIndex(Operator):
         self._table_ref = table_ref
         self._col_list = col_list
         self._vector_store_type = vector_store_type
-        self._function = function
+        self._project_expr_list = project_expr_list
 
     @property
     def name(self):
@@ -1116,8 +1117,8 @@ class LogicalCreateIndex(Operator):
         return self._vector_store_type
 
     @property
-    def function(self):
-        return self._function
+    def project_expr_list(self):
+        return self._project_expr_list
 
     def __eq__(self, other):
         is_subtree_equal = super().__eq__(other)
@@ -1130,7 +1131,7 @@ class LogicalCreateIndex(Operator):
             and self.table_ref == other.table_ref
             and self.col_list == other.col_list
             and self.vector_store_type == other.vector_store_type
-            and self.function == other.function
+            and self.project_expr_list == other.project_expr_list
         )
 
     def __hash__(self) -> int:
@@ -1142,7 +1143,7 @@ class LogicalCreateIndex(Operator):
                 self.table_ref,
                 tuple(self.col_list),
                 self.vector_store_type,
-                self.function,
+                tuple(self.project_expr_list),
             )
         )
 

--- a/evadb/optimizer/operators.py
+++ b/evadb/optimizer/operators.py
@@ -15,7 +15,7 @@
 from collections import deque
 from enum import IntEnum, auto
 from pathlib import Path
-from typing import Any, List, Union
+from typing import Any, List
 
 from evadb.catalog.catalog_type import VectorStoreType
 from evadb.catalog.models.column_catalog import ColumnCatalogEntry
@@ -26,7 +26,6 @@ from evadb.catalog.models.utils import IndexCatalogEntry
 from evadb.expression.abstract_expression import AbstractExpression
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.function_expression import FunctionExpression
-from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.parser.alias import Alias
 from evadb.parser.create_statement import ColumnDefinition
 from evadb.parser.table_ref import TableInfo, TableRef

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -832,8 +832,18 @@ class LogicalCreateIndexToVectorIndex(Rule):
             before.table_ref,
             before.col_list,
             before.vector_store_type,
-            before.function,
+            before.project_expr_list,
         )
+        child = SeqScanPlan(None, before.project_expr_list, before.table_ref.alias)
+        batch_mem_size = context.db.config.get_value("executor", "batch_mem_size")
+        child.append_child(
+            StoragePlan(
+                before.table_ref.table.table_obj,
+                before.table_ref,
+                batch_mem_size=batch_mem_size,
+            )
+        )
+        after.append_child(child)
         yield after
 
 

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -833,6 +833,7 @@ class LogicalCreateIndexToVectorIndex(Rule):
             before.col_list,
             before.vector_store_type,
             before.project_expr_list,
+            before.index_def,
         )
         child = SeqScanPlan(None, before.project_expr_list, before.table_ref.alias)
         batch_mem_size = context.db.config.get_value("executor", "batch_mem_size")

--- a/evadb/optimizer/statement_to_opr_converter.py
+++ b/evadb/optimizer/statement_to_opr_converter.py
@@ -360,6 +360,7 @@ class StatementToPlanConverter:
             statement.col_list,
             statement.vector_store_type,
             statement.project_expr_list,
+            statement.index_def,
         )
         self._plan = create_index_opr
 

--- a/evadb/optimizer/statement_to_opr_converter.py
+++ b/evadb/optimizer/statement_to_opr_converter.py
@@ -359,7 +359,7 @@ class StatementToPlanConverter:
             statement.table_ref,
             statement.col_list,
             statement.vector_store_type,
-            statement.function,
+            statement.project_expr_list,
         )
         self._plan = create_index_opr
 

--- a/evadb/parser/create_index_statement.py
+++ b/evadb/parser/create_index_statement.py
@@ -12,11 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Union
+from typing import List
 
 from evadb.catalog.catalog_type import VectorStoreType
-from evadb.expression.function_expression import FunctionExpression
 from evadb.expression.abstract_expression import AbstractExpression
+from evadb.expression.function_expression import FunctionExpression
 from evadb.parser.create_statement import ColumnDefinition
 from evadb.parser.statement import AbstractStatement
 from evadb.parser.table_ref import TableRef
@@ -83,7 +83,7 @@ class CreateIndexStatement(AbstractStatement):
     @project_expr_list.setter
     def project_expr_list(self, project_expr_list: List[AbstractExpression]):
         self._project_expr_list = project_expr_list
-    
+
     def __eq__(self, other):
         if not isinstance(other, CreateIndexStatement):
             return False
@@ -105,6 +105,6 @@ class CreateIndexStatement(AbstractStatement):
                 self._table_ref,
                 tuple(self.col_list),
                 self._vector_store_type,
-                self._project_expr_list,
+                tuple(self._project_expr_list),
             )
         )

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -26,6 +26,7 @@ from evadb.parser.create_statement import (
 )
 from evadb.parser.table_ref import TableRef
 from evadb.parser.types import ColumnConstraintEnum
+from evadb.catalog.sql_config import ROW_NUM_COLUMN
 
 
 ##################################################################
@@ -256,10 +257,12 @@ class CreateIndex:
                 elif child.data == "index_elem":
                     index_elem = self.visit(child)
 
+        # Projection list of child of index creation.
+        project_expr_list = [TupleValueExpression(name="*")]
+
         # Parse either a single function call or column list.
-        col_list, function = None, None
         if not isinstance(index_elem, list):
-            function = index_elem
+            project_expr_list += [index_elem]
 
             # Traverse to the tuple value expression.
             while not isinstance(index_elem, TupleValueExpression):
@@ -271,7 +274,7 @@ class CreateIndex:
         ]
 
         return CreateIndexStatement(
-            index_name, if_not_exists, table_ref, col_list, vector_store_type, function
+            index_name, if_not_exists, table_ref, col_list, vector_store_type, project_expr_list
         )
 
     def vector_store_type(self, tree):

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -257,7 +257,7 @@ class CreateIndex:
                     index_elem = self.visit(child)
 
         # Projection list of child of index creation.
-        project_expr_list = [TupleValueExpression(name="*")]
+        project_expr_list = []
 
         # Parse either a single function call or column list.
         if not isinstance(index_elem, list):
@@ -268,9 +268,11 @@ class CreateIndex:
                 index_elem = index_elem.children[0]
             index_elem = [index_elem]
 
-        col_list = [
-            ColumnDefinition(tv_expr.name, None, None, None) for tv_expr in index_elem
-        ]
+        # Add tv_expr for projected columns.
+        col_list = []
+        for tv_expr in index_elem:
+            project_expr_list += [tv_expr]
+            col_list += [ColumnDefinition(tv_expr.name, None, None, None)]
 
         return CreateIndexStatement(
             index_name,

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -26,7 +26,6 @@ from evadb.parser.create_statement import (
 )
 from evadb.parser.table_ref import TableRef
 from evadb.parser.types import ColumnConstraintEnum
-from evadb.catalog.sql_config import ROW_NUM_COLUMN
 
 
 ##################################################################
@@ -258,7 +257,7 @@ class CreateIndex:
                     index_elem = self.visit(child)
 
         # Projection list of child of index creation.
-        project_expr_list = [TupleValueExpression(name="*")]
+        project_expr_list = []
 
         # Parse either a single function call or column list.
         if not isinstance(index_elem, list):
@@ -274,7 +273,12 @@ class CreateIndex:
         ]
 
         return CreateIndexStatement(
-            index_name, if_not_exists, table_ref, col_list, vector_store_type, project_expr_list
+            index_name,
+            if_not_exists,
+            table_ref,
+            col_list,
+            vector_store_type,
+            project_expr_list,
         )
 
     def vector_store_type(self, tree):

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -267,11 +267,12 @@ class CreateIndex:
             while not isinstance(index_elem, TupleValueExpression):
                 index_elem = index_elem.children[0]
             index_elem = [index_elem]
+        else:
+            project_expr_list += index_elem
 
         # Add tv_expr for projected columns.
         col_list = []
         for tv_expr in index_elem:
-            project_expr_list += [tv_expr]
             col_list += [ColumnDefinition(tv_expr.name, None, None, None)]
 
         return CreateIndexStatement(

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -257,7 +257,7 @@ class CreateIndex:
                     index_elem = self.visit(child)
 
         # Projection list of child of index creation.
-        project_expr_list = []
+        project_expr_list = [TupleValueExpression(name="*")]
 
         # Parse either a single function call or column list.
         if not isinstance(index_elem, list):

--- a/evadb/plan_nodes/create_index_plan.py
+++ b/evadb/plan_nodes/create_index_plan.py
@@ -12,12 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Union
+from typing import List
 
 from evadb.catalog.catalog_type import VectorStoreType
-from evadb.expression.function_expression import FunctionExpression
-from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.expression.abstract_expression import AbstractExpression
+from evadb.expression.function_expression import FunctionExpression
 from evadb.parser.create_statement import ColumnDefinition
 from evadb.parser.table_ref import TableRef
 from evadb.plan_nodes.abstract_plan import AbstractPlan

--- a/evadb/plan_nodes/create_index_plan.py
+++ b/evadb/plan_nodes/create_index_plan.py
@@ -31,7 +31,8 @@ class CreateIndexPlan(AbstractPlan):
         table_ref: TableRef,
         col_list: List[ColumnDefinition],
         vector_store_type: VectorStoreType,
-        project_expr_list: List[AbstractExpression] = None,
+        project_expr_list: List[AbstractExpression],
+        index_def: str,
     ):
         super().__init__(PlanOprType.CREATE_INDEX)
         self._name = name
@@ -40,6 +41,7 @@ class CreateIndexPlan(AbstractPlan):
         self._col_list = col_list
         self._vector_store_type = vector_store_type
         self._project_expr_list = project_expr_list
+        self._index_def = index_def
 
     @property
     def name(self):
@@ -64,6 +66,10 @@ class CreateIndexPlan(AbstractPlan):
     @property
     def project_expr_list(self):
         return self._project_expr_list
+
+    @property
+    def index_def(self):
+        return self._index_def
 
     def __str__(self):
         function_expr = None
@@ -93,5 +99,6 @@ class CreateIndexPlan(AbstractPlan):
                 tuple(self.col_list),
                 self.vector_store_type,
                 tuple(self.project_expr_list),
+                self.index_def,
             )
         )

--- a/evadb/third_party/vector_stores/faiss.py
+++ b/evadb/third_party/vector_stores/faiss.py
@@ -67,6 +67,7 @@ class FaissVectorStore(VectorStore):
         if len(embedding.shape) != 2:
             embedding = embedding.reshape(1, -1)
 
+        print(embedding.shape, query.top_k)
         dists, indices = self._index.search(embedding, query.top_k)
         distances, ids = [], []
         for dis, idx in zip(dists[0], indices[0]):

--- a/evadb/third_party/vector_stores/faiss.py
+++ b/evadb/third_party/vector_stores/faiss.py
@@ -67,7 +67,6 @@ class FaissVectorStore(VectorStore):
         if len(embedding.shape) != 2:
             embedding = embedding.reshape(1, -1)
 
-        print(embedding.shape, query.top_k)
         dists, indices = self._index.search(embedding, query.top_k)
         distances, ids = [], []
         for dis, idx in zip(dists[0], indices[0]):

--- a/test/integration_tests/long/test_create_index_executor.py
+++ b/test/integration_tests/long/test_create_index_executor.py
@@ -134,6 +134,7 @@ class CreateIndexTest(unittest.TestCase):
     @macos_skip_marker
     def test_should_create_index_faiss(self):
         query = "CREATE INDEX testCreateIndexName ON testCreateIndexFeatTable (feat) USING FAISS;"
+        
         execute_query_fetch_all(self.evadb, query)
 
         # Test index catalog.

--- a/test/integration_tests/long/test_create_index_executor.py
+++ b/test/integration_tests/long/test_create_index_executor.py
@@ -134,7 +134,7 @@ class CreateIndexTest(unittest.TestCase):
     @macos_skip_marker
     def test_should_create_index_faiss(self):
         query = "CREATE INDEX testCreateIndexName ON testCreateIndexFeatTable (feat) USING FAISS;"
-        
+
         execute_query_fetch_all(self.evadb, query)
 
         # Test index catalog.

--- a/test/unit_tests/optimizer/test_statement_to_opr_converter.py
+++ b/test/unit_tests/optimizer/test_statement_to_opr_converter.py
@@ -286,7 +286,13 @@ statement_to_opr_converter.metadata_definition_to_function_metadata"
             MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
         )
         create_index_plan = LogicalCreateIndex(
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
         )
         delete_plan = LogicalDelete(MagicMock())
         insert_plan = LogicalInsert(

--- a/test/unit_tests/optimizer/test_statement_to_opr_converter.py
+++ b/test/unit_tests/optimizer/test_statement_to_opr_converter.py
@@ -286,7 +286,7 @@ statement_to_opr_converter.metadata_definition_to_function_metadata"
             MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
         )
         create_index_plan = LogicalCreateIndex(
-            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
+            MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()
         )
         delete_plan = LogicalDelete(MagicMock())
         insert_plan = LogicalInsert(

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -113,7 +113,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
-            [TupleValueExpression(name="*")],
+            [TupleValueExpression(name="featCol")],
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)
@@ -128,7 +128,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
-            [TupleValueExpression(name="*")],
+            [TupleValueExpression(name="featCol")],
         )
         create_index_query = (
             "CREATE INDEX IF NOT EXISTS testindex ON MyVideo (featCol) USING FAISS;"
@@ -160,7 +160,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
-            [TupleValueExpression(name="*"), func_expr],
+            [func_expr],
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -113,7 +113,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
-            [],
+            [TupleValueExpression(name="*")],
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)
@@ -148,7 +148,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
-            [func_expr],
+            [TupleValueExpression(name="*"), func_expr],
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -117,8 +117,19 @@ class ParserTests(unittest.TestCase):
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)
+        self.assertEqual(actual_stmt.index_def, create_index_query)
 
         # create if_not_exists
+        expected_stmt = CreateIndexStatement(
+            "testindex",
+            True,
+            TableRef(TableInfo("MyVideo")),
+            [
+                ColumnDefinition("featCol", None, None, None),
+            ],
+            VectorStoreType.FAISS,
+            [TupleValueExpression(name="*")],
+        )
         create_index_query = (
             "CREATE INDEX IF NOT EXISTS testindex ON MyVideo (featCol) USING FAISS;"
         )
@@ -126,6 +137,7 @@ class ParserTests(unittest.TestCase):
         actual_stmt = evadb_stmt_list[0]
         expected_stmt._if_not_exists = True
         self.assertEqual(actual_stmt, expected_stmt)
+        self.assertEqual(actual_stmt.index_def, create_index_query)
 
         # create index on Function expression
         create_index_query = (
@@ -152,6 +164,7 @@ class ParserTests(unittest.TestCase):
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)
+        self.assertEqual(actual_stmt.index_def, create_index_query)
 
     @unittest.skip("Skip parser exception handling testcase, moved to binder")
     def test_create_index_exception_statement(self):

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -113,7 +113,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
-            TupleValueExpression("featCol"),
+            [],
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)
@@ -148,7 +148,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
-            func_expr,
+            [func_expr],
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -113,6 +113,7 @@ class ParserTests(unittest.TestCase):
                 ColumnDefinition("featCol", None, None, None),
             ],
             VectorStoreType.FAISS,
+            TupleValueExpression("featCol"),
         )
         actual_stmt = evadb_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)


### PR DESCRIPTION
The first step to do automatic index updates on insertions. 

Replace the old version of creating an index, which directly reads data from the storage engine. 

It now reads data from the children's plans: SeqScan and Storage. 