### PR TITLE
feat: run additional functional expression during an index scan

### DIFF
--- a/test/integration_tests/long/test_similarity.py
+++ b/test/integration_tests/long/test_similarity.py
@@ -389,14 +389,15 @@ class SimilarityTests(unittest.TestCase):
                                         USING FAISS;"""
             execute_query_fetch_all(self.evadb, create_index_query)
 
-            select_query = """SELECT _row_id FROM testSimilarityImageDataset
+            select_query = """SELECT _row_id, Similarity(DummyFeatureExtractor(Open("{}")), DummyFeatureExtractor(data)) FROM testSimilarityImageDataset
                                 ORDER BY Similarity(DummyFeatureExtractor(Open("{}")), DummyFeatureExtractor(data))
                                 LIMIT 1;""".format(
-                self.img_path
+                self.img_path, self.img_path,
             )
             explain_batch = execute_query_fetch_all(
                 self.evadb, f"EXPLAIN {select_query}"
             )
+            print(explain_batch.frames[0][0])
             self.assertTrue("VectorIndexScan" in explain_batch.frames[0][0])
 
             res_batch = execute_query_fetch_all(self.evadb, select_query)


### PR DESCRIPTION
I am currently trying to support the below query
```sql
SELECT _row_id, Similarity(DummyFeatureExtractor(Open("{}")), DummyFeatureExtractor(data)) 
  FROM testSimilarityImageDataset
  ORDER BY Similarity(DummyFeatureExtractor(Open("{}")), DummyFeatureExtractor(data))
  LIMIT 1
```

It will be converted to such a plan with my current change.
```
|__ ProjectPlan
    |__ VectorIndexScanPlan
        |__ ApplyAndMergePlan
            |__ SeqScanPlan
                |__ StoragePlan
```

It will become very inefficient for the function expression because it is applied on all rows. Any possible way to overcome this? @xzdandy @gaurav274 