### PR TITLE
Remove dimensions from `TEXT` and `FLOAT`

### DIFF
--- a/docs/source/reference/evaql/create.rst
+++ b/docs/source/reference/evaql/create.rst
@@ -68,7 +68,7 @@ Below are all supported column types:
 
 .. note::
 
-   Check `NdArrayType <https://github.com/georgia-tech-db/evadb/blob/staging/evadb/catalog/catalog_type.py#L61>`_ for available NDARRAY types.
+   Check `NdArrayType <https://github.com/georgia-tech-db/evadb/blob/staging/evadb/catalog/catalog_type.py>`_ for available NDARRAY types.
 
 We can also create table from the output of a ``SELECT`` query.
 

--- a/docs/source/reference/evaql/create.rst
+++ b/docs/source/reference/evaql/create.rst
@@ -35,19 +35,57 @@ Examples
 CREATE TABLE
 ------------
 
-To create a table, specify the schema of the table.
+To create a table, we can specify the schema of the table.
+
+.. code-block::
+
+   CREATE TABLE [IF NOT EXISTS] table_name ( [
+     column_name data_type
+     [, ... ]
+   ] );
+
+Blew is an example:
 
 .. code:: mysql
 
    CREATE TABLE IF NOT EXISTS MyCSV (
-                   id INTEGER UNIQUE,
-                   frame_id INTEGER,
-                   video_id INTEGER,
-                   dataset_name TEXT(30),
-                   label TEXT(30),
-                   bbox NDARRAY FLOAT32(4),
-                   object_id INTEGER
-    );
+     id INTEGER UNIQUE,
+     frame_id INTEGER,
+     video_id INTEGER,
+     dataset_name TEXT,
+     label TEXT,
+     bbox NDARRAY FLOAT32(4),
+     object_id INTEGER
+   );
+
+Below are all supported column types:
+
+* INTEGER
+* TEXT
+* FLOAT
+* NDARRAY 
+* BOOLEAN
+
+.. note::
+
+   Check `NdArrayType <https://github.com/georgia-tech-db/evadb/blob/staging/evadb/catalog/catalog_type.py#L61>`_ for available NDARRAY types.
+
+We can also create table from the output of a ``SELECT`` query.
+
+.. code-block::
+
+   CREATE TABLE [IF NOT EXISTS] table_name 
+   AS select_query
+
+Below is an example:
+
+.. code-block:: sql
+
+    CREATE TABLE UADETRAC_FastRCNN AS
+    SELECT id, FastRCNNObjectDetector(frame).labels 
+    FROM UADETRAC
+    WHERE id<5;
+
 
 CREATE INDEX
 ------------
@@ -119,14 +157,3 @@ Where the `parameter` is ``key value`` pair.
 
    Go over :ref:`hf`, :ref:`ludwig`, and :ref:`forecast` to check examples for creating function via type.
 
-CREATE MATERIALIZED VIEW
-------------------------
-
-To create a view with materialized results -- like the outputs of deep learning model, use the following template:
-
-.. code-block:: sql
-
-    CREATE MATERIALIZED VIEW UADETRAC_FastRCNN (id, labels) AS
-    SELECT id, FastRCNNObjectDetector(frame).labels 
-    FROM UADETRAC
-    WHERE id<5;

--- a/docs/source/shared/postgresql.rst
+++ b/docs/source/shared/postgresql.rst
@@ -5,7 +5,7 @@ We will assume that you have a ``PostgreSQL`` database server running locally th
 
 EvaDB lets you connect to your favorite databases, data warehouses, data lakes, etc., via the ``CREATE DATABASE`` statement. In this query, we connect EvaDB to an existing ``PostgreSQL`` server:
 
-.. code-block:: text
+.. code-block::
 
     CREATE DATABASE postgres_data 
     WITH ENGINE = 'postgres', 

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -158,6 +158,9 @@ class CreateTable:
         elif str.upper(token) == "TEXT":
             data_type = ColumnType.TEXT
 
+        if len(tree.children) > 1:
+            dimensions = self.visit(tree.children[1])
+
         return data_type, array_type, dimensions
 
     def array_data_type(self, tree):

--- a/evadb/parser/lark_visitor/_create_statements.py
+++ b/evadb/parser/lark_visitor/_create_statements.py
@@ -155,10 +155,8 @@ class CreateTable:
         token = tree.children[0]
         if str.upper(token) == "FLOAT":
             data_type = ColumnType.FLOAT
-            dimensions = self.visit(tree.children[1])
         elif str.upper(token) == "TEXT":
             data_type = ColumnType.TEXT
-            dimensions = self.visit(tree.children[1])
 
         return data_type, array_type, dimensions
 

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -266,6 +266,53 @@ class ParserTests(unittest.TestCase):
             self.assertIsInstance(evadb_statement_list[0], AbstractStatement)
             self.assertEqual(evadb_statement_list[0], expected_stmt)
 
+    def test_create_table_with_dimension_statement(self):
+        # The test is for backwards compatibility
+        parser = Parser()
+
+        single_queries = []
+        single_queries.append(
+            """CREATE TABLE IF NOT EXISTS Persons (
+                  Frame_ID INTEGER UNIQUE,
+                  Frame_Data TEXT(10),
+                  Frame_Value FLOAT(1000, 201),
+                  Frame_Array NDARRAY UINT8(5, 100, 2432, 4324, 100)
+            );"""
+        )
+
+        expected_cci = ColConstraintInfo()
+        expected_cci.nullable = True
+        unique_cci = ColConstraintInfo()
+        unique_cci.unique = True
+        unique_cci.nullable = False
+        expected_stmt = CreateTableStatement(
+            TableInfo("Persons"),
+            True,
+            [
+                ColumnDefinition("Frame_ID", ColumnType.INTEGER, None, (), unique_cci),
+                ColumnDefinition(
+                    "Frame_Data", ColumnType.TEXT, None, (10,), expected_cci
+                ),
+                ColumnDefinition(
+                    "Frame_Value", ColumnType.FLOAT, None, (1000, 201), expected_cci
+                ),
+                ColumnDefinition(
+                    "Frame_Array",
+                    ColumnType.NDARRAY,
+                    NdArrayType.UINT8,
+                    (5, 100, 2432, 4324, 100),
+                    expected_cci,
+                ),
+            ],
+        )
+
+        for query in single_queries:
+            evadb_statement_list = parser.parse(query)
+            self.assertIsInstance(evadb_statement_list, list)
+            self.assertEqual(len(evadb_statement_list), 1)
+            self.assertIsInstance(evadb_statement_list[0], AbstractStatement)
+            self.assertEqual(evadb_statement_list[0], expected_stmt)
+
     def test_create_table_statement_with_rare_datatypes(self):
         parser = Parser()
         query = """CREATE TABLE IF NOT EXISTS Dummy (

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -229,8 +229,8 @@ class ParserTests(unittest.TestCase):
         single_queries.append(
             """CREATE TABLE IF NOT EXISTS Persons (
                   Frame_ID INTEGER UNIQUE,
-                  Frame_Data TEXT(10),
-                  Frame_Value FLOAT(1000, 201),
+                  Frame_Data TEXT,
+                  Frame_Value FLOAT,
                   Frame_Array NDARRAY UINT8(5, 100, 2432, 4324, 100)
             );"""
         )

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -245,11 +245,9 @@ class ParserTests(unittest.TestCase):
             True,
             [
                 ColumnDefinition("Frame_ID", ColumnType.INTEGER, None, (), unique_cci),
+                ColumnDefinition("Frame_Data", ColumnType.TEXT, None, (), expected_cci),
                 ColumnDefinition(
-                    "Frame_Data", ColumnType.TEXT, None, (10,), expected_cci
-                ),
-                ColumnDefinition(
-                    "Frame_Value", ColumnType.FLOAT, None, (1000, 201), expected_cci
+                    "Frame_Value", ColumnType.FLOAT, None, (), expected_cci
                 ),
                 ColumnDefinition(
                     "Frame_Array",


### PR DESCRIPTION
Users can now create a table with just `FLOAT` without providing the dimensions.

Earlier:
```sql
CREATE TABLE ETTM1 (
        date TEXT(30),
        hufl FLOAT(5,7),
        hull FLOAT(5,7),
        mufl FLOAT(5,7),
        mull FLOAT(5,7),
        lufl FLOAT(5,7),
        lull FLOAT(5,7),
        ot FLOAT(5,7));
```

Now:
```sql
CREATE TABLE ETTM1 (
        date TEXT,
        hufl FLOAT,
        hull FLOAT,
        mufl FLOAT,
        mull FLOAT,
        lufl FLOAT,
        lull FLOAT,
        ot FLOAT);
```

Fixes #1260.

