### PR TITLE
Improve the error message when there is a typo in the column name in the query. 

### DIFF
--- a/evadb/binder/statement_binder_context.py
+++ b/evadb/binder/statement_binder_context.py
@@ -146,8 +146,8 @@ class StatementBinderContext:
         col_name = col_name.lower()
 
         def raise_error():
-            all_columns = list(
-                set([col for _, col in self._get_all_alias_and_col_name()])
+            all_columns = sorted(
+                list(set([col for _, col in self._get_all_alias_and_col_name()]))
             )
             guess_column, _ = process.extractOne(col_name, all_columns)
             err_msg = f"Cannnot find column {col_name}. Did you mean {guess_column}? The available columns are {all_columns}."

--- a/evadb/binder/statement_binder_context.py
+++ b/evadb/binder/statement_binder_context.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 from typing import Callable, Dict, List, Tuple, Union
 
+from thefuzz import process
+
 from evadb.binder.binder_utils import (
     BinderError,
     check_data_source_and_table_are_valid,
@@ -144,7 +146,11 @@ class StatementBinderContext:
         col_name = col_name.lower()
 
         def raise_error():
-            err_msg = f"Found invalid column {col_name}"
+            all_columns = list(
+                set([col for _, col in self._get_all_alias_and_col_name()])
+            )
+            guess_column, _ = process.extractOne(col_name, all_columns)
+            err_msg = f"Cannnot find column {col_name}. Did you mean {guess_column}? The available columns are {all_columns}."
             logger.error(err_msg)
             raise BinderError(err_msg)
 

--- a/evadb/binder/statement_binder_context.py
+++ b/evadb/binder/statement_binder_context.py
@@ -149,8 +149,14 @@ class StatementBinderContext:
             all_columns = sorted(
                 list(set([col for _, col in self._get_all_alias_and_col_name()]))
             )
-            guess_column, _ = process.extractOne(col_name, all_columns)
-            err_msg = f"Cannnot find column {col_name}. Did you mean {guess_column}? The available columns are {all_columns}."
+            res = process.extractOne(col_name, all_columns)
+            if res is not None:
+                guess_column, _ = res
+                err_msg = f"Cannnot find column {col_name}. Did you mean {guess_column}? The feasible columns are {all_columns}."
+            else:
+                err_msg = (
+                    f"Cannnot find column {col_name}. There are no feasible columns."
+                )
             logger.error(err_msg)
             raise BinderError(err_msg)
 

--- a/test/integration_tests/short/test_select_executor.py
+++ b/test/integration_tests/short/test_select_executor.py
@@ -102,6 +102,16 @@ class SelectExecutorTest(unittest.TestCase):
             BinderError, execute_query_fetch_all, self.evadb, select_query
         )
 
+    def test_should_raise_binder_error_on_non_existent_column(self):
+        select_query = "SELECT b1 FROM table1;"
+
+        with self.assertRaises(BinderError) as ctx:
+            execute_query_fetch_all(self.evadb, select_query)
+        self.assertEqual(
+            "Cannnot find column b1. Did you mean a1? The available columns are ['_row_id', 'a0', 'a1', 'a2'].",
+            str(ctx.exception),
+        )
+
     def test_should_select_star_in_nested_query(self):
         select_query = """SELECT * FROM (SELECT * FROM MyVideo) AS T;"""
         actual_batch = execute_query_fetch_all(self.evadb, select_query)

--- a/test/integration_tests/short/test_select_executor.py
+++ b/test/integration_tests/short/test_select_executor.py
@@ -108,7 +108,7 @@ class SelectExecutorTest(unittest.TestCase):
         with self.assertRaises(BinderError) as ctx:
             execute_query_fetch_all(self.evadb, select_query)
         self.assertEqual(
-            "Cannnot find column b1. Did you mean a1? The available columns are ['_row_id', 'a0', 'a1', 'a2'].",
+            "Cannnot find column b1. Did you mean a1? The feasible columns are ['_row_id', 'a0', 'a1', 'a2'].",
             str(ctx.exception),
         )
 

--- a/test/unit_tests/binder/test_statement_binder_context.py
+++ b/test/unit_tests/binder/test_statement_binder_context.py
@@ -110,7 +110,7 @@ class StatementBinderTests(unittest.TestCase):
         with self.assertRaises(BinderError):
             ctx = StatementBinderContext(MagicMock())
             mock_search_all = ctx._search_all_alias_maps = MagicMock()
-            mock_search_all.return_value = []
+            mock_search_all.return_value = (None, None)
             ctx.get_binded_column("col_name")
         # with alias
         with self.assertRaises(BinderError):

--- a/test/unit_tests/binder/test_statement_binder_context.py
+++ b/test/unit_tests/binder/test_statement_binder_context.py
@@ -110,7 +110,7 @@ class StatementBinderTests(unittest.TestCase):
         with self.assertRaises(BinderError):
             ctx = StatementBinderContext(MagicMock())
             mock_search_all = ctx._search_all_alias_maps = MagicMock()
-            mock_search_all.return_value = (None, None)
+            mock_search_all.return_value = []
             ctx.get_binded_column("col_name")
         # with alias
         with self.assertRaises(BinderError):


### PR DESCRIPTION
- [x] Add basic functionality

Below is the example error message:

```
evadb.binder.binder_utils.BinderError: Cannnot find column name2. Did you mean name? The available columns are ['avatar_url', 'bio', 'blog', 'collaborators', 'company', 'contributions', 'disk_usage', 'email', 'events_url', 'followers', 'followers_url', 'following', 'following_url', 'gists_url', 'gravatar_id', 'hireable', 'html_url', 'id', 'invitation_teams_url', 'location', 'login', 'name', 'node_id', 'organizations_url', 'owned_private_repos', 'private_gists', 'public_gists', 'public_repos', 'received_events_url', 'repos_url', 'role', 'site_admin', 'starred_url', 'subscriptions_url', 'team_count', 'total_private_repos', 'twitter_username', 'type', 'url'].
```

**Limitation**: To keep the output clean, we only do fuzzy match on the columns and skip the alias.  

- [x] Add testcases.  