### PR TITLE
Cost-based Batch Size 

### DIFF
--- a/evadb/executor/storage_executor.py
+++ b/evadb/executor/storage_executor.py
@@ -49,7 +49,7 @@ class StorageExecutor(AbstractExecutor):
             elif self.node.table.table_type == TableType.STRUCTURED_DATA:
                 return storage_engine.read(self.node.table, self.node.batch_mem_size)
             elif self.node.table.table_type == TableType.NATIVE_DATA:
-                return storage_engine.read(self.node.table)
+                return storage_engine.read(self.node.table, self.node.batch_mem_size)
             elif self.node.table.table_type == TableType.PDF_DATA:
                 return storage_engine.read(self.node.table)
             else:

--- a/evadb/optimizer/group_expression.py
+++ b/evadb/optimizer/group_expression.py
@@ -82,6 +82,9 @@ class GroupExpression:
             and self.children == other.children
         )
 
+    def __repr__(self) -> str:
+        return self.__str__()
+
     def __str__(self) -> str:
         return "%s(%s)" % (
             type(self).__name__,

--- a/evadb/optimizer/optimizer_tasks.py
+++ b/evadb/optimizer/optimizer_tasks.py
@@ -305,6 +305,7 @@ class OptimizeInputs(OptimizerTask):
                 return
 
         cost += self.optimizer_context.cost_model.calculate_cost(self.root_expr)
+        print((self.root_expr, cost))
         grp.add_expr_cost(self.root_expr, PropertyType.DEFAULT, cost)
 
 


### PR DESCRIPTION
To start with, we follow a simple cost-based rule:
1. Use the maximum batch size from storage engine when there is no limit
2. Use the minimum (1) batch size from storage engine when there is limit. 