### PR TITLE
Add documentation note for connecting to existing SQL DB

### DIFF
--- a/docs/source/overview/connect-to-data-sources.rst
+++ b/docs/source/overview/connect-to-data-sources.rst
@@ -6,10 +6,6 @@ EvaDB supports a wide range of data sources including SQL database systems, obje
 Connect to an Existing SQL Database System
 ------------------------------------------
 
-.. note::
-
-   For prototyping, users can opt to establish a connection to :ref:`SQLite<sqlite>`.
-
 1. Use the :ref:`CREATE DATABASE<create-database>` statement to connect to an **existing** SQL database.
 
 .. code-block::
@@ -27,6 +23,10 @@ Connect to an Existing SQL Database System
 .. note::
 
    Go over the :ref:`CREATE DATABASE<create-database>` statement for more details. The :ref:`Databases<databases>` page lists all the database systems that EvaDB currently supports.
+
+.. note::
+
+   For prototyping, users can opt to establish a connection to :ref:`SQLite<sqlite>`.
 
 2. Preview the data using ``SELECT``
 

--- a/docs/source/overview/connect-to-data-sources.rst
+++ b/docs/source/overview/connect-to-data-sources.rst
@@ -6,6 +6,12 @@ EvaDB supports a wide range of data sources including SQL database systems, obje
 Connect to an Existing SQL Database System
 ------------------------------------------
 
+.. note::
+
+   Connecting to an existing SQL database is unnecessary for inserting or querying data in Eva. This step is only required if
+   users intend to work with data already present in some SQL DB. Eva has native storage support for SQLite, which can be utilized without
+   establishing any connection. Refer to :ref:`EvaQL<evaql>` page for more details.
+
 1. Use the :ref:`CREATE DATABASE<create-database>` statement to connect to an **existing** SQL database.
 
 .. code-block::
@@ -82,6 +88,6 @@ You can use the ``CREATE INDEX`` statement to connect to an existing vector data
 
 .. note::
 
-   Go over the :ref:`CREATE INDEX<create-index>` statement for more details. The :ref:`Vector Databases<databases>` page lists all the vector database systems that EvaDB currently supports.
+   Go over the :ref:`CREATE INDEX<create-index>` statement for more details. The :ref:`Vector Databases<vector_databases>` page lists all the vector database systems that EvaDB currently supports.
 
 .. include:: ../shared/designs/design3.rst

--- a/docs/source/overview/connect-to-data-sources.rst
+++ b/docs/source/overview/connect-to-data-sources.rst
@@ -8,9 +8,7 @@ Connect to an Existing SQL Database System
 
 .. note::
 
-   Connecting to an existing SQL database is unnecessary for inserting or querying data in Eva. This step is only required if
-   users intend to work with data already present in some SQL DB. Eva has native storage support for SQLite, which can be utilized without
-   establishing any connection. Refer to :ref:`EvaQL<evaql>` page for more details.
+   For prototyping, users can opt to establish a connection to :ref:`SQLite<sqlite>`.
 
 1. Use the :ref:`CREATE DATABASE<create-database>` statement to connect to an **existing** SQL database.
 

--- a/docs/source/reference/databases/sqlite.rst
+++ b/docs/source/reference/databases/sqlite.rst
@@ -1,3 +1,5 @@
+.. _sqlite:
+
 SQLite
 ==========
 
@@ -16,7 +18,7 @@ Required:
 
 * `database` is the path to the database file to be opened. You can pass ":memory:" to create an SQLite database existing only in memory, and open a connection to it.
 
-.. warning:: 
+.. note:: 
 
      If the ``database`` parameter is specified, EvaDB connects to the already existing ``sqlite`` database specified. Otherwise, it automatically creates a new ``sqlite`` database named ``evadb.db``.
 

--- a/docs/source/reference/evaql.rst
+++ b/docs/source/reference/evaql.rst
@@ -1,3 +1,5 @@
+.. _evaql:
+
 EvaDB Query Language (EvaQL)
 ============================
 

--- a/docs/source/usecases/classification.rst
+++ b/docs/source/usecases/classification.rst
@@ -31,6 +31,10 @@ In this tutorial, we present how to to create and train a machine learning model
 We will assume that the input data is loaded into a ``PostgreSQL`` database. 
 To load the home rental data into your database, see the complete `home rental prediction notebook on Colab <https://colab.research.google.com/github/georgia-tech-db/eva/blob/staging/tutorials/17-home-rental-prediction.ipynb>`_.
 
+.. note::
+
+   For prototyping, users can opt to establish a connection to :ref:`SQLite<sqlite>`.
+
 Preview the Home Rental Price Data
 ----------------------------------
 

--- a/docs/source/usecases/forecasting.rst
+++ b/docs/source/usecases/forecasting.rst
@@ -31,6 +31,10 @@ In this tutorial, we present how to create and train a machine learning model fo
 We will assume that the input data is loaded into a ``PostgreSQL`` database. 
 To load the home sales dataset into your database, see the complete `home sale forecasting notebook on Colab <https://colab.research.google.com/github/georgia-tech-db/eva/blob/staging/tutorials/16-homesale-forecasting.ipynb>`_.
 
+.. note::
+
+   For prototyping, users can opt to establish a connection to :ref:`SQLite<sqlite>`.
+
 Preview the Home Sale Price Data
 --------------------------------
 

--- a/docs/source/usecases/sentiment-analysis.rst
+++ b/docs/source/usecases/sentiment-analysis.rst
@@ -31,6 +31,10 @@ To load the food review data into your database, see the complete `sentiment ana
 
 .. include:: ../shared/postgresql.rst
 
+.. note::
+
+   For prototyping, users can opt to establish a connection to :ref:`SQLite<sqlite>`.
+
 Sentiment Analysis of Reviews using ChatGPT
 -------------------------------------------
 


### PR DESCRIPTION
I have seen students getting confused with the documentation wherein they try to always create a connection to some database (Eg : Postgres) before trying to insert or query data. Adding a note in the documentation to help clear this point up as well as describe that Eva has native storage support for SQLite.