### PR TITLE
Add test_eva_db to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ env.bak/
 venv.bak/
 env38/
 env_eva/
+test_eva_db/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
The environment created in the setup instructions in the documentation calls the environment `test_eva_db`