### PR TITLE
Return a forecasting plot with the output

### DIFF
--- a/docs/source/reference/ai/model-forecasting.rst
+++ b/docs/source/reference/ai/model-forecasting.rst
@@ -75,7 +75,7 @@ EvaDB's default forecast framework is `statsforecast <https://nixtla.github.io/s
 
 .. note::
   
-   `Forecasting` function also logs suggestions. Logged information, such as metrics and suggestions, is sent to STDOUT by default. If you wish not to print it, please send `FALSE` as an optional argument while calling the function. Eg. `SELECT Forecast(FALSE);`
+   `Forecasting` function also logs suggestions. Logged information, such as metrics and suggestions, is sent to STDOUT by default. A figure is also plotted and is saved in a binary format supported by OpenCV in the `plot` column of the output table. It maybe rendered using the `cv2.imdecode` function. If you wish not to obtain the logged information, please send `FALSE` as an optional argument while calling the function. Eg. `SELECT Forecast(FALSE);`
 
 
 Below is an example query specifying the above parameters:

--- a/evadb/binder/statement_binder.py
+++ b/evadb/binder/statement_binder.py
@@ -134,6 +134,12 @@ class StatementBinder:
                             None,
                             None,
                         ),
+                        ColumnDefinition(
+                            "plot",
+                            ColumnType.ANY,
+                            None,
+                            None,
+                        ),
                     ]
                 )
             else:

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -646,8 +646,8 @@ class CreateFunctionExecutor(AbstractExecutor):
             model_path = os.path.join(model_dir, existing_model_files[-1])
         io_list = self._resolve_function_io(None)
         data["ds"] = data.ds.astype(str)
-        last_ds = list(data["ds"])[-2*horizon:]
-        last_y = list(data["y"])[-2*horizon:]
+        last_ds = list(data["ds"])[-2 * horizon :]
+        last_y = list(data["y"])[-2 * horizon :]
         metadata_here = [
             FunctionMetadataCatalogEntry("model_name", arg_map["model"]),
             FunctionMetadataCatalogEntry("model_path", model_path),

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -646,6 +646,8 @@ class CreateFunctionExecutor(AbstractExecutor):
             model_path = os.path.join(model_dir, existing_model_files[-1])
         io_list = self._resolve_function_io(None)
         data["ds"] = data.ds.astype(str)
+        last_ds = list(data["ds"])[-2*horizon:]
+        last_y = list(data["y"])[-2*horizon:]
         metadata_here = [
             FunctionMetadataCatalogEntry("model_name", arg_map["model"]),
             FunctionMetadataCatalogEntry("model_path", model_path),
@@ -661,6 +663,8 @@ class CreateFunctionExecutor(AbstractExecutor):
             FunctionMetadataCatalogEntry("horizon", horizon),
             FunctionMetadataCatalogEntry("library", library),
             FunctionMetadataCatalogEntry("conf", conf),
+            FunctionMetadataCatalogEntry("last_ds", last_ds),
+            FunctionMetadataCatalogEntry("last_y", last_y),
         ]
 
         return (

--- a/evadb/expression/function_expression.py
+++ b/evadb/expression/function_expression.py
@@ -130,8 +130,12 @@ class FunctionExpression(AbstractExpression):
 
             # process outcomes only if output is not empty
             if outcomes.frames.empty is False:
-                outcomes = outcomes.project(self.projection_columns)
-                outcomes.modify_column_alias(self.alias)
+                if self._function().name == "ForecastModel":
+                    outcomes = outcomes.project(self.projection_columns, forecast=True)
+                    outcomes.modify_column_alias(self.alias, forecast=True)
+                else:
+                    outcomes = outcomes.project(self.projection_columns)
+                    outcomes.modify_column_alias(self.alias)
 
         # record the number of function calls
         self._stats.num_calls += len(batch)

--- a/evadb/functions/forecast.py
+++ b/evadb/functions/forecast.py
@@ -86,7 +86,7 @@ class ForecastModel(AbstractFunction):
 
         # Feedback
         if len(data) == 0 or list(list(data.iloc[0]))[0] is True:
-            # Suggestions
+            ## Suggestions
             suggestion_list = []
             # 1: Flat predictions
             if self.library == "statsforecast":
@@ -102,7 +102,7 @@ class ForecastModel(AbstractFunction):
             for suggestion in set(suggestion_list):
                 log_str += "\nSUGGESTION: " + self.suggestion_dict[suggestion]
 
-            # Metrics
+            ## Metrics
             if self.rmse is not None:
                 log_str += "\nMean normalized RMSE: " + str(self.rmse)
             if self.hypers is not None:
@@ -142,7 +142,7 @@ class ForecastModel(AbstractFunction):
             plt.legend()
             plt.tight_layout()
 
-            # convert plt figure to opencv https://copyprogramming.com/howto/convert-matplotlib-figure-to-cv2-image-a-complete-guide-with-examples#converting-matplotlib-figure-to-cv2-image
+            # convert plt figure to opencv, inspired from https://copyprogramming.com/howto/convert-matplotlib-figure-to-cv2-image-a-complete-guide-with-examples#converting-matplotlib-figure-to-cv2-image
             # convert figure to canvas
             canvas = plt.get_current_fig_manager().canvas
 
@@ -156,12 +156,14 @@ class ForecastModel(AbstractFunction):
             # convert image to cv2 format
             cv2_img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
 
-            ## Conver to bytes
+            # Conver to bytes
             _, buffer = cv2.imencode(".jpg", cv2_img)
             img_bytes = buffer.tobytes()
 
-            ## Add to dataframe as a plot
+            # Add to dataframe as a plot
             forecast_df["plot"] = [img_bytes] + [None] * (len(forecast_df) - 1)
+
+            log_str += "\nA plot has been saved in the 'plot' column of the output table. It maybe rendered using the cv2.imdecode function."
 
             print(log_str)
 

--- a/evadb/functions/forecast.py
+++ b/evadb/functions/forecast.py
@@ -39,6 +39,8 @@ class ForecastModel(AbstractFunction):
         horizon: int,
         library: str,
         conf: int,
+        last_ds: list,
+        last_y: list
     ):
         self.library = library
         if "neuralforecast" in self.library:
@@ -67,6 +69,8 @@ class ForecastModel(AbstractFunction):
                 self.rmse = float(f.readline())
                 if "arima" in model_name.lower():
                     self.hypers = "p,d,q: " + f.readline()
+        self.last_ds = last_ds
+        self.last_y = last_y
 
     def forward(self, data) -> pd.DataFrame:
         log_str = ""
@@ -100,6 +104,10 @@ class ForecastModel(AbstractFunction):
                 log_str += "\nMean normalized RMSE: " + str(self.rmse)
             if self.hypers is not None:
                 log_str += "\nHyperparameters: " + self.hypers
+            import pudb; pu.db
+
+            # Plot figure
+            
 
             print(log_str)
 


### PR DESCRIPTION
Fixes #1344.

The forecasting plot is encoded using `cv2.imencode` and sent as a binary string in the first row of a new `plot` column that is created in the output table when a forecasting UDF is called. It shows the original series, along with the forecast and confidence intervals.

Sample plot:

![test](https://github.com/georgia-tech-db/evadb/assets/23132358/05180b71-a344-421d-8139-ce6549b6938a)
