### PR TITLE
Make Logic Operators Case Insensitve

### DIFF
--- a/evadb/parser/lark_visitor/_expressions.py
+++ b/evadb/parser/lark_visitor/_expressions.py
@@ -16,11 +16,11 @@ import numpy as np
 from lark import Tree
 
 from evadb.catalog.catalog_type import ColumnType
-from evadb.utils.generic_utils import string_comparison_case_insensitive
 from evadb.expression.abstract_expression import ExpressionType
 from evadb.expression.comparison_expression import ComparisonExpression
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.logical_expression import LogicalExpression
+from evadb.utils.generic_utils import string_comparison_case_insensitive
 
 
 ##################################################################

--- a/evadb/parser/lark_visitor/_expressions.py
+++ b/evadb/parser/lark_visitor/_expressions.py
@@ -16,6 +16,7 @@ import numpy as np
 from lark import Tree
 
 from evadb.catalog.catalog_type import ColumnType
+from evadb.utils.generic_utils import string_comparison_case_insensitive
 from evadb.expression.abstract_expression import ExpressionType
 from evadb.expression.comparison_expression import ComparisonExpression
 from evadb.expression.constant_value_expression import ConstantValueExpression
@@ -101,10 +102,12 @@ class Expressions:
     def logical_operator(self, tree):
         op = str(tree.children[0])
 
-        if op == "OR":
+        if string_comparison_case_insensitive(op, "OR"):
             return ExpressionType.LOGICAL_OR
-        elif op == "AND":
+        elif string_comparison_case_insensitive(op, "AND"):
             return ExpressionType.LOGICAL_AND
+        else:
+            raise NotImplementedError("Unsupported logical operator: {}".format(op))
 
     def expressions_with_defaults(self, tree):
         expr_list = []

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -22,6 +22,7 @@ from evadb.expression.comparison_expression import ComparisonExpression
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.function_expression import FunctionExpression
 from evadb.expression.tuple_value_expression import TupleValueExpression
+from evadb.expression.logical_expression import LogicalExpression
 from evadb.parser.alias import Alias
 from evadb.parser.create_function_statement import CreateFunctionStatement
 from evadb.parser.create_index_statement import CreateIndexStatement
@@ -530,6 +531,56 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(select_stmt_new.target_list, select_stmt.target_list)
         self.assertEqual(select_stmt_new.from_table, select_stmt.from_table)
         self.assertEqual(str(select_stmt_new), str(select_stmt))
+
+    def test_select_statement_where_class(self):
+        """
+        Unit test for logical operators in the where clause.
+        """
+
+        parser = Parser()
+        select_query_new = "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' AND REDNESS < 400;"
+        evadb_statement_list = parser.parse(select_query_new)
+
+        self.assertIsInstance(evadb_statement_list, list)
+        self.assertEqual(len(evadb_statement_list), 1)
+        self.assertEqual(evadb_statement_list[0].stmt_type, StatementType.SELECT)
+
+        select_stmt = evadb_statement_list[0]
+
+        # target list
+        self.assertIsNotNone(select_stmt.target_list)
+        self.assertEqual(len(select_stmt.target_list), 2)
+        self.assertEqual(select_stmt.target_list[0].etype, ExpressionType.TUPLE_VALUE)
+        self.assertEqual(select_stmt.target_list[0].name, "CLASS")
+        self.assertEqual(select_stmt.target_list[1].etype, ExpressionType.TUPLE_VALUE)
+        self.assertEqual(select_stmt.target_list[1].name, "REDNESS")
+
+        # from table
+        self.assertIsNotNone(select_stmt.from_table)
+        self.assertIsInstance(select_stmt.from_table, TableRef)
+        self.assertEqual(select_stmt.from_table.table.table_name, "TAIPAI")
+
+        # where clause
+        self.assertIsNotNone(select_stmt.where_clause)
+        self.assertIsInstance(select_stmt.where_clause, LogicalExpression)
+        self.assertEqual(select_stmt.where_clause.etype, ExpressionType.LOGICAL_AND)
+        self.assertEqual(len(select_stmt.where_clause.children), 2)
+        left = select_stmt.where_clause.children[0]
+        right = select_stmt.where_clause.children[1]
+        self.assertEqual(left.etype, ExpressionType.COMPARE_EQUAL)
+        self.assertEqual(right.etype, ExpressionType.COMPARE_LESSER)
+        
+        self.assertEqual(len(left.children), 2)
+        self.assertEqual(left.children[0].etype, ExpressionType.TUPLE_VALUE)
+        self.assertEqual(left.children[0].name, "CLASS")
+        self.assertEqual(left.children[1].etype, ExpressionType.CONSTANT_VALUE)
+        self.assertEqual(left.children[1].value, "VAN")
+
+        self.assertEqual(len(right.children), 2)
+        self.assertEqual(right.children[0].etype, ExpressionType.TUPLE_VALUE)
+        self.assertEqual(right.children[0].name, "REDNESS")
+        self.assertEqual(right.children[1].etype, ExpressionType.CONSTANT_VALUE)
+        self.assertEqual(right.children[1].value, 400)
 
     def test_select_statement_groupby_class(self):
         """Testing sample frequency"""

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -21,8 +21,8 @@ from evadb.expression.abstract_expression import ExpressionType
 from evadb.expression.comparison_expression import ComparisonExpression
 from evadb.expression.constant_value_expression import ConstantValueExpression
 from evadb.expression.function_expression import FunctionExpression
-from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.expression.logical_expression import LogicalExpression
+from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.parser.alias import Alias
 from evadb.parser.create_function_statement import CreateFunctionStatement
 from evadb.parser.create_index_statement import CreateIndexStatement
@@ -547,9 +547,13 @@ class ParserTests(unittest.TestCase):
             # target list
             self.assertIsNotNone(select_stmt.target_list)
             self.assertEqual(len(select_stmt.target_list), 2)
-            self.assertEqual(select_stmt.target_list[0].etype, ExpressionType.TUPLE_VALUE)
+            self.assertEqual(
+                select_stmt.target_list[0].etype, ExpressionType.TUPLE_VALUE
+            )
             self.assertEqual(select_stmt.target_list[0].name, "CLASS")
-            self.assertEqual(select_stmt.target_list[1].etype, ExpressionType.TUPLE_VALUE)
+            self.assertEqual(
+                select_stmt.target_list[1].etype, ExpressionType.TUPLE_VALUE
+            )
             self.assertEqual(select_stmt.target_list[1].name, "REDNESS")
 
             # from table
@@ -566,7 +570,7 @@ class ParserTests(unittest.TestCase):
             right = select_stmt.where_clause.children[1]
             self.assertEqual(left.etype, ExpressionType.COMPARE_EQUAL)
             self.assertEqual(right.etype, ExpressionType.COMPARE_LESSER)
-            
+
             self.assertEqual(len(left.children), 2)
             self.assertEqual(left.children[0].etype, ExpressionType.TUPLE_VALUE)
             self.assertEqual(left.children[0].name, "CLASS")
@@ -580,19 +584,24 @@ class ParserTests(unittest.TestCase):
             self.assertEqual(right.children[1].value, 400)
 
         parser = Parser()
-        select_query = "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' AND REDNESS < 400;"
+        select_query = (
+            "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' AND REDNESS < 400;"
+        )
         _verify_select_statement(parser.parse(select_query))
 
         # Case insensitive test
-        select_query = "select CLASS, REDNESS from TAIPAI where CLASS = 'VAN' and REDNESS < 400;"
+        select_query = (
+            "select CLASS, REDNESS from TAIPAI where CLASS = 'VAN' and REDNESS < 400;"
+        )
         _verify_select_statement(parser.parse(select_query))
 
         # Unsupported logical operator
-        select_query = "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' XOR REDNESS < 400;"
+        select_query = (
+            "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' XOR REDNESS < 400;"
+        )
         with self.assertRaises(NotImplementedError) as cm:
             parser.parse(select_query)
         self.assertEqual(str(cm.exception), "Unsupported logical operator: XOR")
-
 
     def test_select_statement_groupby_class(self):
         """Testing sample frequency"""

--- a/test/unit_tests/parser/test_parser.py
+++ b/test/unit_tests/parser/test_parser.py
@@ -537,50 +537,62 @@ class ParserTests(unittest.TestCase):
         Unit test for logical operators in the where clause.
         """
 
+        def _verify_select_statement(evadb_statement_list):
+            self.assertIsInstance(evadb_statement_list, list)
+            self.assertEqual(len(evadb_statement_list), 1)
+            self.assertEqual(evadb_statement_list[0].stmt_type, StatementType.SELECT)
+
+            select_stmt = evadb_statement_list[0]
+
+            # target list
+            self.assertIsNotNone(select_stmt.target_list)
+            self.assertEqual(len(select_stmt.target_list), 2)
+            self.assertEqual(select_stmt.target_list[0].etype, ExpressionType.TUPLE_VALUE)
+            self.assertEqual(select_stmt.target_list[0].name, "CLASS")
+            self.assertEqual(select_stmt.target_list[1].etype, ExpressionType.TUPLE_VALUE)
+            self.assertEqual(select_stmt.target_list[1].name, "REDNESS")
+
+            # from table
+            self.assertIsNotNone(select_stmt.from_table)
+            self.assertIsInstance(select_stmt.from_table, TableRef)
+            self.assertEqual(select_stmt.from_table.table.table_name, "TAIPAI")
+
+            # where clause
+            self.assertIsNotNone(select_stmt.where_clause)
+            self.assertIsInstance(select_stmt.where_clause, LogicalExpression)
+            self.assertEqual(select_stmt.where_clause.etype, ExpressionType.LOGICAL_AND)
+            self.assertEqual(len(select_stmt.where_clause.children), 2)
+            left = select_stmt.where_clause.children[0]
+            right = select_stmt.where_clause.children[1]
+            self.assertEqual(left.etype, ExpressionType.COMPARE_EQUAL)
+            self.assertEqual(right.etype, ExpressionType.COMPARE_LESSER)
+            
+            self.assertEqual(len(left.children), 2)
+            self.assertEqual(left.children[0].etype, ExpressionType.TUPLE_VALUE)
+            self.assertEqual(left.children[0].name, "CLASS")
+            self.assertEqual(left.children[1].etype, ExpressionType.CONSTANT_VALUE)
+            self.assertEqual(left.children[1].value, "VAN")
+
+            self.assertEqual(len(right.children), 2)
+            self.assertEqual(right.children[0].etype, ExpressionType.TUPLE_VALUE)
+            self.assertEqual(right.children[0].name, "REDNESS")
+            self.assertEqual(right.children[1].etype, ExpressionType.CONSTANT_VALUE)
+            self.assertEqual(right.children[1].value, 400)
+
         parser = Parser()
-        select_query_new = "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' AND REDNESS < 400;"
-        evadb_statement_list = parser.parse(select_query_new)
+        select_query = "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' AND REDNESS < 400;"
+        _verify_select_statement(parser.parse(select_query))
 
-        self.assertIsInstance(evadb_statement_list, list)
-        self.assertEqual(len(evadb_statement_list), 1)
-        self.assertEqual(evadb_statement_list[0].stmt_type, StatementType.SELECT)
+        # Case insensitive test
+        select_query = "select CLASS, REDNESS from TAIPAI where CLASS = 'VAN' and REDNESS < 400;"
+        _verify_select_statement(parser.parse(select_query))
 
-        select_stmt = evadb_statement_list[0]
+        # Unsupported logical operator
+        select_query = "SELECT CLASS, REDNESS FROM TAIPAI WHERE CLASS = 'VAN' XOR REDNESS < 400;"
+        with self.assertRaises(NotImplementedError) as cm:
+            parser.parse(select_query)
+        self.assertEqual(str(cm.exception), "Unsupported logical operator: XOR")
 
-        # target list
-        self.assertIsNotNone(select_stmt.target_list)
-        self.assertEqual(len(select_stmt.target_list), 2)
-        self.assertEqual(select_stmt.target_list[0].etype, ExpressionType.TUPLE_VALUE)
-        self.assertEqual(select_stmt.target_list[0].name, "CLASS")
-        self.assertEqual(select_stmt.target_list[1].etype, ExpressionType.TUPLE_VALUE)
-        self.assertEqual(select_stmt.target_list[1].name, "REDNESS")
-
-        # from table
-        self.assertIsNotNone(select_stmt.from_table)
-        self.assertIsInstance(select_stmt.from_table, TableRef)
-        self.assertEqual(select_stmt.from_table.table.table_name, "TAIPAI")
-
-        # where clause
-        self.assertIsNotNone(select_stmt.where_clause)
-        self.assertIsInstance(select_stmt.where_clause, LogicalExpression)
-        self.assertEqual(select_stmt.where_clause.etype, ExpressionType.LOGICAL_AND)
-        self.assertEqual(len(select_stmt.where_clause.children), 2)
-        left = select_stmt.where_clause.children[0]
-        right = select_stmt.where_clause.children[1]
-        self.assertEqual(left.etype, ExpressionType.COMPARE_EQUAL)
-        self.assertEqual(right.etype, ExpressionType.COMPARE_LESSER)
-        
-        self.assertEqual(len(left.children), 2)
-        self.assertEqual(left.children[0].etype, ExpressionType.TUPLE_VALUE)
-        self.assertEqual(left.children[0].name, "CLASS")
-        self.assertEqual(left.children[1].etype, ExpressionType.CONSTANT_VALUE)
-        self.assertEqual(left.children[1].value, "VAN")
-
-        self.assertEqual(len(right.children), 2)
-        self.assertEqual(right.children[0].etype, ExpressionType.TUPLE_VALUE)
-        self.assertEqual(right.children[0].name, "REDNESS")
-        self.assertEqual(right.children[1].etype, ExpressionType.CONSTANT_VALUE)
-        self.assertEqual(right.children[1].value, 400)
 
     def test_select_statement_groupby_class(self):
         """Testing sample frequency"""


### PR DESCRIPTION
Fix the following queries:

```
SELECT * FROM postgres_data.home_rentals where neighborhood='downtown' and number_of_rooms=2;
```