### PR TITLE
Migrate ChatGPT function to openai v1.0

### DIFF
--- a/evadb/functions/chatgpt.py
+++ b/evadb/functions/chatgpt.py
@@ -124,9 +124,7 @@ class ChatGPT(AbstractFunction):
             len(api_key) != 0
         ), "Please set your OpenAI API key using SET OPENAI_API_KEY = 'sk-' or environment variable (OPENAI_API_KEY)"
 
-        client = OpenAI(
-            api_key=api_key
-        )
+        client = OpenAI(api_key=api_key)
 
         @retry(tries=6, delay=20)
         def completion_with_backoff(**kwargs):

--- a/evadb/functions/chatgpt.py
+++ b/evadb/functions/chatgpt.py
@@ -115,18 +115,22 @@ class ChatGPT(AbstractFunction):
     )
     def forward(self, text_df):
         try_to_import_openai()
-        import openai
+        from openai import OpenAI
+
+        api_key = self.openai_api_key
+        if len(self.openai_api_key) == 0:
+            api_key = os.environ.get("OPENAI_API_KEY", "")
+        assert (
+            len(api_key) != 0
+        ), "Please set your OpenAI API key using SET OPENAI_API_KEY = 'sk-' or environment variable (OPENAI_API_KEY)"
+
+        client = OpenAI(
+            api_key=api_key
+        )
 
         @retry(tries=6, delay=20)
         def completion_with_backoff(**kwargs):
-            return openai.ChatCompletion.create(**kwargs)
-
-        openai.api_key = self.openai_api_key
-        if len(openai.api_key) == 0:
-            openai.api_key = os.environ.get("OPENAI_API_KEY", "")
-        assert (
-            len(openai.api_key) != 0
-        ), "Please set your OpenAI API key using SET OPENAI_API_KEY = 'sk-' or environment variable (OPENAI_API_KEY)"
+            return client.chat.completions.create(**kwargs)
 
         queries = text_df[text_df.columns[0]]
         content = text_df[text_df.columns[0]]

--- a/evadb/functions/dalle.py
+++ b/evadb/functions/dalle.py
@@ -56,24 +56,25 @@ class DallEFunction(AbstractFunction):
     )
     def forward(self, text_df):
         try_to_import_openai()
-        import openai
+        from openai import OpenAI
 
-        openai.api_key = self.openai_api_key
-        # If not found, try OS Environment Variable
-        if len(openai.api_key) == 0:
-            openai.api_key = os.environ.get("OPENAI_API_KEY", "")
+        api_key = self.openai_api_key
+        if len(self.openai_api_key) == 0:
+            api_key = os.environ.get("OPENAI_API_KEY", "")
         assert (
-            len(openai.api_key) != 0
-        ), "Please set your OpenAI API key using SET OPENAI_API_KEY = 'sk-'  or environment variable (OPENAI_API_KEY)"
+            len(api_key) != 0
+        ), "Please set your OpenAI API key using SET OPENAI_API_KEY = 'sk-' or environment variable (OPENAI_API_KEY)"
+
+        client = OpenAI(api_key=api_key)
 
         def generate_image(text_df: PandasDataframe):
             results = []
             queries = text_df[text_df.columns[0]]
             for query in queries:
-                response = openai.Image.create(prompt=query, n=1, size="1024x1024")
+                response = client.images.generate(prompt=query, n=1, size="1024x1024")
 
                 # Download the image from the link
-                image_response = requests.get(response["data"][0]["url"])
+                image_response = requests.get(response.data[0].url)
                 image = Image.open(BytesIO(image_response.content))
 
                 # Convert the image to an array format suitable for the DataFrame

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ document_libs = [
     "sentence-transformers",
     "protobuf",
     "bs4",
-    "openai==0.28",  # CHATGPT
+    "openai>=1.0",  # CHATGPT
     "gpt4all",  # PRIVATE GPT
     "sentencepiece",  # TRANSFORMERS
 ]

--- a/test/integration_tests/long/functions/test_chatgpt.py
+++ b/test/integration_tests/long/functions/test_chatgpt.py
@@ -60,7 +60,7 @@ class ChatGPTTest(unittest.TestCase):
     def tearDown(self) -> None:
         execute_query_fetch_all(self.evadb, "DROP TABLE IF EXISTS MyTextCSV;")
 
-    # @chatgpt_skip_marker
+    @chatgpt_skip_marker
     def test_openai_chat_completion_function(self):
         function_name = "ChatGPT"
         execute_query_fetch_all(self.evadb, f"DROP FUNCTION IF EXISTS {function_name};")

--- a/test/integration_tests/long/functions/test_chatgpt.py
+++ b/test/integration_tests/long/functions/test_chatgpt.py
@@ -53,9 +53,7 @@ class ChatGPTTest(unittest.TestCase):
 
         csv_query = f"""LOAD CSV '{self.csv_file_path}' INTO MyTextCSV;"""
         execute_query_fetch_all(self.evadb, csv_query)
-        os.environ[
-            "OPENAI_API_KEY"
-        ] = "sk-..."
+        os.environ["OPENAI_API_KEY"] = "sk-..."
 
     def tearDown(self) -> None:
         execute_query_fetch_all(self.evadb, "DROP TABLE IF EXISTS MyTextCSV;")

--- a/test/integration_tests/long/functions/test_chatgpt.py
+++ b/test/integration_tests/long/functions/test_chatgpt.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from test.markers import chatgpt_skip_marker
 from test.util import get_evadb_for_testing
@@ -22,9 +23,8 @@ import pandas as pd
 from evadb.server.command_handler import execute_query_fetch_all
 
 
-def create_dummy_csv_file(config) -> str:
-    tmp_dir_from_config = config.get_value("storage", "tmp_dir")
-
+def create_dummy_csv_file(catalog) -> str:
+    tmp_dir_from_config = catalog.get_configuration_catalog_value("tmp_dir")
     df_dict = [
         {
             "prompt": "summarize",
@@ -49,17 +49,20 @@ class ChatGPTTest(unittest.TestCase):
             );"""
         execute_query_fetch_all(self.evadb, create_table_query)
 
-        self.csv_file_path = create_dummy_csv_file(self.evadb.config)
+        self.csv_file_path = create_dummy_csv_file(self.evadb.catalog())
 
         csv_query = f"""LOAD CSV '{self.csv_file_path}' INTO MyTextCSV;"""
         execute_query_fetch_all(self.evadb, csv_query)
+        os.environ[
+            "OPENAI_API_KEY"
+        ] = "sk-..."
 
     def tearDown(self) -> None:
         execute_query_fetch_all(self.evadb, "DROP TABLE IF EXISTS MyTextCSV;")
 
-    @chatgpt_skip_marker
+    # @chatgpt_skip_marker
     def test_openai_chat_completion_function(self):
-        function_name = "OpenAIChatCompletion"
+        function_name = "ChatGPT"
         execute_query_fetch_all(self.evadb, f"DROP FUNCTION IF EXISTS {function_name};")
 
         create_function_query = f"""CREATE FUNCTION IF NOT EXISTS{function_name}
@@ -69,4 +72,4 @@ class ChatGPTTest(unittest.TestCase):
 
         gpt_query = f"SELECT {function_name}('summarize', content) FROM MyTextCSV;"
         output_batch = execute_query_fetch_all(self.evadb, gpt_query)
-        self.assertEqual(output_batch.columns, ["openaichatcompletion.response"])
+        self.assertEqual(output_batch.columns, ["chatgpt.response"])

--- a/test/unit_tests/test_dalle.py
+++ b/test/unit_tests/test_dalle.py
@@ -16,14 +16,13 @@
 import unittest
 from io import BytesIO
 from test.util import get_evadb_for_testing
+from typing import List, Optional
 from unittest.mock import MagicMock, patch
 
 from PIL import Image as PILImage
+from pydantic import AnyUrl, BaseModel
 
 from evadb.server.command_handler import execute_query_fetch_all
-
-from typing import List, Optional
-from pydantic import BaseModel, AnyUrl
 
 
 class Image(BaseModel):
@@ -76,7 +75,7 @@ class DallEFunctionTest(unittest.TestCase):
                 Image(
                     b64_json=None,
                     revised_prompt=None,
-                    url="https://images.openai.com/1234.png"
+                    url="https://images.openai.com/1234.png",
                 )
             ]
         )


### PR DESCRIPTION
Migrate ChatGPT function to openai v1.0.

The test is skipped in circleCI because we must supply the `OPENAI_API_KEY`. The test passes on local machine.

- [x] Upgrade ChatGPT function.
- [x] Upgrade Dall-e function.
- [x] Update unit test cases.
- [x] Verify that notebooks work correctly.