### PR TITLE
fix: Issues with function input names not matching the column name

### DIFF
--- a/evadb/expression/function_expression.py
+++ b/evadb/expression/function_expression.py
@@ -184,6 +184,14 @@ class FunctionExpression(AbstractExpression):
             [child.evaluate(batch, **kwargs) for child in self.children]
         )
 
+        # Rename the columns according to args from input signatures
+        if self.function_obj is not None:
+            col_renaming = {
+                original_col: arg.name
+                for original_col, arg in zip(func_args.columns, self.function_obj.args)
+            }
+            func_args.rename(col_renaming)
+
         if not self._cache:
             return func_args.apply_function_expression(func)
 

--- a/evadb/functions/function_bootstrap_queries.py
+++ b/evadb/functions/function_bootstrap_queries.py
@@ -63,6 +63,13 @@ DummyLLM_function_query = """CREATE FUNCTION
     EvaDB_INSTALLATION_DIR
 )
 
+DummyAccessColumnByName_function_query = """CREATE FUNCTION
+                  IF NOT EXISTS DummyAccessColumnByName
+                  IMPL '{}/../test/util.py';
+        """.format(
+    EvaDB_INSTALLATION_DIR
+)
+
 fuzzy_function_query = """CREATE FUNCTION IF NOT EXISTS FuzzDistance
                     INPUT (Input_Array1 NDARRAY ANYTYPE, Input_Array2 NDARRAY ANYTYPE)
                     OUTPUT (distance FLOAT(32, 7))
@@ -299,6 +306,7 @@ def init_builtin_functions(db: EvaDBDatabase, mode: str = "debug") -> None:
                 DummyFeatureExtractor_function_query,
                 DummyNoInputFunction_function_query,
                 DummyLLM_function_query,
+                DummyAccessColumnByName_function_query,
             ]
         )
 

--- a/test/integration_tests/short/test_select_executor.py
+++ b/test/integration_tests/short/test_select_executor.py
@@ -452,3 +452,18 @@ class SelectExecutorTest(unittest.TestCase):
             pd.DataFrame([{"dummynoinputfunction.label": "DummyNoInputFunction"}])
         )
         self.assertEqual(actual_batch, expected)
+
+    def test_nested_function_calls(self):
+        select_query = "SELECT DummyAccessColumnByName(DummyAccessColumnByName(id, data)) from MyVideo;"
+        actual_batch = execute_query_fetch_all(self.evadb, select_query)
+        expected = Batch(
+            pd.DataFrame(
+                [
+                    {
+                        "dummyaccesscolumnbyname.output1": True,
+                        "dummyaccesscolumnbyname.output2": True,
+                    }
+                ]
+            )
+        )
+        self.assertEqual(actual_batch, expected)

--- a/test/util.py
+++ b/test/util.py
@@ -719,3 +719,35 @@ class DummyLLM(AbstractFunction):
         # Make it slower
         time.sleep(1)
         return df
+
+
+class DummyAccessColumnByName(AbstractFunction):
+    @decorators.setup(cacheable=False, function_type="test", batchable=False)
+    def setup(self, *args, **kwargs):
+        pass
+
+    @property
+    def name(self) -> str:
+        return "DummyAccessColumnByName"
+
+    @decorators.forward(
+        input_signatures=[
+            PandasDataframe(
+                columns=["input1", "input2"],
+                column_types=[NdArrayType.ANYTYPE, NdArrayType.ANYTYPE],
+                column_shapes=[(None,), (None,)],
+            )
+        ],
+        output_signatures=[
+            PandasDataframe(
+                columns=["output1", "output2"],
+                column_types=[NdArrayType.ANYTYPE, NdArrayType.ANYTYPE],
+                column_shapes=[(None,), (None,)],
+            )
+        ],
+    )
+    def forward(self, df: pd.DataFrame) -> pd.DataFrame:
+        ret = pd.DataFrame(
+            [{"output1": df["input1"] is not None, "output2": df["input2"] is not None}]
+        )
+        return ret


### PR DESCRIPTION
Fixing #1206 by renaming the input columns on the fly when executing UDFs. 

The renaming is according to the `columns` attribute in `input_signatures` of UDFs. 