### PR TITLE
feat: supporting spaces in column names for csv files

### DIFF
--- a/docs/source/overview/faq.rst
+++ b/docs/source/overview/faq.rst
@@ -34,3 +34,16 @@ If a query runs a complex AI task (e.g., sentiment analysis) on a large table, t
     top
     pgrep evadb_server
 
+Can column names have space?
+----------------------------
+
+For column names with space, you can use reverse quote to contain the column names. Below are example `CREATE TABLE` and `SELECT` queries:
+
+.. code-block:: sql
+
+   CREATE TABLE IF NOT EXISTS MyVideoCSV (
+        id INTEGER UNIQUE,
+        `frame id` INTEGER,
+   );
+
+   SELECT id, `frame id` FROM MyVideoCSV;

--- a/evadb/parser/lark_visitor/_common_clauses_ids.py
+++ b/evadb/parser/lark_visitor/_common_clauses_ids.py
@@ -43,9 +43,12 @@ class CommonClauses:
             return (self.visit(tree.children[0]), self.visit(tree.children[1]))
 
     def uid(self, tree):
-        if (hasattr(tree.children[0],"type") and tree.children[0].type == "REVERSE_QUOTE_ID"):
+        if (
+            hasattr(tree.children[0], "type")
+            and tree.children[0].type == "REVERSE_QUOTE_ID"
+        ):
             tree.children[0].type = "simple_id"
-            non_tick_string = str(tree.children[0]).replace("`","")
+            non_tick_string = str(tree.children[0]).replace("`", "")
             return non_tick_string
         return self.visit(tree.children[0])
 

--- a/evadb/parser/lark_visitor/_common_clauses_ids.py
+++ b/evadb/parser/lark_visitor/_common_clauses_ids.py
@@ -43,6 +43,11 @@ class CommonClauses:
             return (self.visit(tree.children[0]), self.visit(tree.children[1]))
 
     def uid(self, tree):
+        if (hasattr(tree.children[0],"type") and tree.children[0].type == "REVERSE_QUOTE_ID"):
+            # tree.children[0].value = tree.children[0].value.replace("`","")
+            temp = str(tree.children[0]).replace("`","")
+            tree.children[0].type = "simple_id"
+            return temp
         return self.visit(tree.children[0])
 
     def full_column_name(self, tree):

--- a/evadb/parser/lark_visitor/_common_clauses_ids.py
+++ b/evadb/parser/lark_visitor/_common_clauses_ids.py
@@ -44,10 +44,9 @@ class CommonClauses:
 
     def uid(self, tree):
         if (hasattr(tree.children[0],"type") and tree.children[0].type == "REVERSE_QUOTE_ID"):
-            # tree.children[0].value = tree.children[0].value.replace("`","")
-            temp = str(tree.children[0]).replace("`","")
             tree.children[0].type = "simple_id"
-            return temp
+            non_tick_string = str(tree.children[0]).replace("`","")
+            return non_tick_string
         return self.visit(tree.children[0])
 
     def full_column_name(self, tree):

--- a/test/integration_tests/short/test_load_executor.py
+++ b/test/integration_tests/short/test_load_executor.py
@@ -46,7 +46,6 @@ class LoadExecutorTests(unittest.TestCase):
             f"{EvaDB_ROOT_DIR}/test/data/uadetrac/small-data/MVI_20011/*.jpg"
         )
         self.csv_file_path = create_sample_csv()
-        self.csv_file_with_spaces_path = create_csv_with_comlumn_name_spaces()
 
     def tearDown(self):
         shutdown_ray()
@@ -126,7 +125,7 @@ class LoadExecutorTests(unittest.TestCase):
         create_table_query = """
 
             CREATE TABLE IF NOT EXISTS MyVideoCSV (
-                id INTEGER UNIQUE, 
+                id INTEGER UNIQUE,
                 `frame id` INTEGER,
                 `video id` INTEGER,
                 `dataset name` TEXT(30),
@@ -139,7 +138,7 @@ class LoadExecutorTests(unittest.TestCase):
         execute_query_fetch_all(self.evadb, create_table_query)
 
         # load the CSV
-        load_query = f"LOAD CSV '{self.csv_file_with_spaces_path}' INTO MyVideoCSV;"
+        load_query = f"LOAD CSV '{create_csv_with_comlumn_name_spaces()}' INTO MyVideoCSV;"
         execute_query_fetch_all(self.evadb, load_query)
 
         # execute a select query

--- a/test/integration_tests/short/test_load_executor.py
+++ b/test/integration_tests/short/test_load_executor.py
@@ -17,9 +17,9 @@ import os
 import unittest
 from pathlib import Path
 from test.util import (
+    create_csv_with_comlumn_name_spaces,
     create_dummy_csv_batches,
     create_sample_csv,
-    create_csv_with_comlumn_name_spaces,
     create_sample_video,
     file_remove,
     get_evadb_for_testing,
@@ -138,7 +138,9 @@ class LoadExecutorTests(unittest.TestCase):
         execute_query_fetch_all(self.evadb, create_table_query)
 
         # load the CSV
-        load_query = f"LOAD CSV '{create_csv_with_comlumn_name_spaces()}' INTO MyVideoCSV;"
+        load_query = (
+            f"LOAD CSV '{create_csv_with_comlumn_name_spaces()}' INTO MyVideoCSV;"
+        )
         execute_query_fetch_all(self.evadb, load_query)
 
         # execute a select query

--- a/test/integration_tests/short/test_load_executor.py
+++ b/test/integration_tests/short/test_load_executor.py
@@ -84,7 +84,7 @@ class LoadExecutorTests(unittest.TestCase):
 
             CREATE TABLE IF NOT EXISTS MyVideoCSV (
                 id INTEGER UNIQUE,
-                frame_id INTEGER,
+                `frame_id` INTEGER,
                 video_id INTEGER,
                 dataset_name TEXT(30),
                 label TEXT(30),
@@ -100,7 +100,7 @@ class LoadExecutorTests(unittest.TestCase):
         execute_query_fetch_all(self.evadb, load_query)
 
         # execute a select query
-        select_query = """SELECT id, frame_id, video_id,
+        select_query = """SELECT id, `frame_id`, video_id,
                           dataset_name, label, bbox,
                           object_id
                           FROM MyVideoCSV;"""

--- a/test/util.py
+++ b/test/util.py
@@ -304,7 +304,7 @@ def create_sample_csv(num_frames=NUM_FRAMES):
             random_coords = 200 + 300 * np.random.random(4)
             sample_meta[index] = {
                 "id": index,
-                "frame_id": frame_id,
+                "frame id": frame_id,
                 "video_id": video_id,
                 "dataset_name": "test_dataset",
                 "label": sample_labels[np.random.choice(len(sample_labels))],

--- a/test/util.py
+++ b/test/util.py
@@ -318,6 +318,7 @@ def create_sample_csv(num_frames=NUM_FRAMES):
     df_sample_meta.to_csv(os.path.join(get_tmp_dir(), "dummy.csv"), index=False)
     return os.path.join(get_tmp_dir(), "dummy.csv")
 
+
 def create_csv_with_comlumn_name_spaces(num_frames=NUM_FRAMES):
     try:
         os.remove(os.path.join(get_tmp_dir(), "dummy.csv"))
@@ -334,7 +335,7 @@ def create_csv_with_comlumn_name_spaces(num_frames=NUM_FRAMES):
             random_coords = 200 + 300 * np.random.random(4)
             sample_meta[index] = {
                 "id": index,
-                "frame id": frame_id, 
+                "frame id": frame_id,
                 "video id": video_id,
                 "dataset name": "test_dataset",
                 "label": sample_labels[np.random.choice(len(sample_labels))],

--- a/test/util.py
+++ b/test/util.py
@@ -304,12 +304,42 @@ def create_sample_csv(num_frames=NUM_FRAMES):
             random_coords = 200 + 300 * np.random.random(4)
             sample_meta[index] = {
                 "id": index,
-                "frame id": frame_id,
+                "frame_id": frame_id,
                 "video_id": video_id,
                 "dataset_name": "test_dataset",
                 "label": sample_labels[np.random.choice(len(sample_labels))],
                 "bbox": ",".join([str(coord) for coord in random_coords]),
                 "object_id": np.random.choice(3),
+            }
+
+            index += 1
+
+    df_sample_meta = pd.DataFrame.from_dict(sample_meta, "index")
+    df_sample_meta.to_csv(os.path.join(get_tmp_dir(), "dummy.csv"), index=False)
+    return os.path.join(get_tmp_dir(), "dummy.csv")
+
+def create_csv_with_comlumn_name_spaces(num_frames=NUM_FRAMES):
+    try:
+        os.remove(os.path.join(get_tmp_dir(), "dummy.csv"))
+    except FileNotFoundError:
+        pass
+
+    sample_meta = {}
+
+    index = 0
+    sample_labels = ["car", "pedestrian", "bicycle"]
+    num_videos = 2
+    for video_id in range(num_videos):
+        for frame_id in range(num_frames):
+            random_coords = 200 + 300 * np.random.random(4)
+            sample_meta[index] = {
+                "id": index,
+                "frame id": frame_id, 
+                "video id": video_id,
+                "dataset name": "test_dataset",
+                "label": sample_labels[np.random.choice(len(sample_labels))],
+                "bbox": ",".join([str(coord) for coord in random_coords]),
+                "object id": np.random.choice(3),
             }
 
             index += 1


### PR DESCRIPTION
takes `reverse quote id`, removes back ticks, and converts it to `simple id`. 