### PR TITLE
WIP: Job scheduler SQL statements

### DIFF
--- a/evadb/executor/plan_executor.py
+++ b/evadb/executor/plan_executor.py
@@ -44,6 +44,7 @@ from evadb.executor.sample_executor import SampleExecutor
 from evadb.executor.seq_scan_executor import SequentialScanExecutor
 from evadb.executor.set_executor import SetExecutor
 from evadb.executor.show_info_executor import ShowInfoExecutor
+from evadb.executor.start_scheduler_executor import StartSchedulerExecutor
 from evadb.executor.storage_executor import StorageExecutor
 from evadb.executor.union_executor import UnionExecutor
 from evadb.executor.use_executor import UseExecutor
@@ -51,6 +52,7 @@ from evadb.executor.vector_index_scan_executor import VectorIndexScanExecutor
 from evadb.models.storage.batch import Batch
 from evadb.parser.create_statement import CreateDatabaseStatement, CreateJobStatement
 from evadb.parser.set_statement import SetStatement
+from evadb.parser.start_scheduler_statement import StartSchedulerStatement
 from evadb.parser.statement import AbstractStatement
 from evadb.parser.use_statement import UseStatement
 from evadb.plan_nodes.abstract_plan import AbstractPlan
@@ -96,6 +98,8 @@ class PlanExecutor:
             return SetExecutor(db=self._db, node=plan)
         elif isinstance(plan, CreateJobStatement):
             return CreateJobExecutor(db=self._db, node=plan)
+        elif isinstance(plan, StartSchedulerStatement):
+            return StartSchedulerExecutor(db=self._db, node=plan)
 
         # Get plan node type
         plan_opr_type = plan.opr_type

--- a/evadb/executor/plan_executor.py
+++ b/evadb/executor/plan_executor.py
@@ -45,6 +45,7 @@ from evadb.executor.seq_scan_executor import SequentialScanExecutor
 from evadb.executor.set_executor import SetExecutor
 from evadb.executor.show_info_executor import ShowInfoExecutor
 from evadb.executor.start_scheduler_executor import StartSchedulerExecutor
+from evadb.executor.stop_scheduler_executor import StopSchedulerExecutor
 from evadb.executor.storage_executor import StorageExecutor
 from evadb.executor.union_executor import UnionExecutor
 from evadb.executor.use_executor import UseExecutor
@@ -53,6 +54,7 @@ from evadb.models.storage.batch import Batch
 from evadb.parser.create_statement import CreateDatabaseStatement, CreateJobStatement
 from evadb.parser.set_statement import SetStatement
 from evadb.parser.start_scheduler_statement import StartSchedulerStatement
+from evadb.parser.stop_scheduler_statement import StopSchedulerStatement
 from evadb.parser.statement import AbstractStatement
 from evadb.parser.use_statement import UseStatement
 from evadb.plan_nodes.abstract_plan import AbstractPlan
@@ -100,6 +102,8 @@ class PlanExecutor:
             return CreateJobExecutor(db=self._db, node=plan)
         elif isinstance(plan, StartSchedulerStatement):
             return StartSchedulerExecutor(db=self._db, node=plan)
+        elif isinstance(plan, StopSchedulerStatement):
+            return StopSchedulerExecutor(db=self._db, node=plan)
 
         # Get plan node type
         plan_opr_type = plan.opr_type

--- a/evadb/executor/start_scheduler_executor.py
+++ b/evadb/executor/start_scheduler_executor.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import multiprocessing
+from evadb.database import EvaDBDatabase
+from evadb.executor.abstract_executor import AbstractExecutor
+from evadb.parser.set_statement import SetStatement
+from evadb.utils.logging_manager import logger
+
+class StartSchedulerExecutor(AbstractExecutor):
+    def __init__(self, db: EvaDBDatabase, node: SetStatement):
+        super().__init__(db, node)
+
+    def exec(self, *args, **kwargs):
+        logger.debug("No op for StartSchedulerExecutor")

--- a/evadb/executor/stop_scheduler_executor.py
+++ b/evadb/executor/stop_scheduler_executor.py
@@ -15,12 +15,12 @@
 import multiprocessing
 from evadb.database import EvaDBDatabase
 from evadb.executor.abstract_executor import AbstractExecutor
-from evadb.parser.start_scheduler_statement import StartSchedulerStatement
+from evadb.parser.stop_scheduler_statement import StopSchedulerStatement
 from evadb.utils.logging_manager import logger
 
-class StartSchedulerExecutor(AbstractExecutor):
-    def __init__(self, db: EvaDBDatabase, node: StartSchedulerStatement):
+class StopSchedulerExecutor(AbstractExecutor):
+    def __init__(self, db: EvaDBDatabase, node: StopSchedulerStatement):
         super().__init__(db, node)
 
     def exec(self, *args, **kwargs):
-        logger.debug("No op for StartSchedulerExecutor")
+        logger.debug("No op for StopSchedulerExecutor")

--- a/evadb/parser/evadb.lark
+++ b/evadb/parser/evadb.lark
@@ -4,7 +4,7 @@
 // because we assume that inside the job, the user can specify multiple sql_statements
 // but not a create_job within a create_job.
 
-start: (sql_statement? ";")+ | (create_job ";") | (start_scheduler_statement ";") | (stop_scheduler_statement ";")
+start: (sql_statement? ";")+ | (create_job ";")
 
 sql_statement: ddl_statement | dml_statement | utility_statement | context_statement
 
@@ -14,7 +14,7 @@ ddl_statement: create_database | create_table | create_index | create_function |
 dml_statement: select_statement | insert_statement | update_statement
     | delete_statement | load_statement | set_statement
     
-utility_statement: describe_statement | show_statement | help_statement | explain_statement
+utility_statement: describe_statement | show_statement | help_statement | explain_statement | start_scheduler_statement | stop_scheduler_statement
 
 context_statement: use_statement
 

--- a/evadb/parser/evadb.lark
+++ b/evadb/parser/evadb.lark
@@ -4,7 +4,7 @@
 // because we assume that inside the job, the user can specify multiple sql_statements
 // but not a create_job within a create_job.
 
-start: (sql_statement? ";")+ | (create_job ";") | (start_scheduler_statement ";")
+start: (sql_statement? ";")+ | (create_job ";") | (start_scheduler_statement ";") | (stop_scheduler_statement ";")
 
 sql_statement: ddl_statement | dml_statement | utility_statement | context_statement
 
@@ -204,6 +204,8 @@ explain_statement: EXPLAIN explainable_statement
 explainable_statement : select_statement | insert_statement | update_statement | delete_statement | create_table
 
 start_scheduler_statement : START JOB_SCHEDULER
+
+stop_scheduler_statement : STOP JOB_SCHEDULER
 
 // Context Statements
 
@@ -419,6 +421,7 @@ SHUTDOWN:                            "SHUTDOWN"i
 SHOW:                                "SHOW"i
 SOME:                                "SOME"i
 START:                               "START"i
+STOP:                                "STOP"i
 TABLE:                               "TABLE"i
 TABLES:                              "TABLES"i
 TO:                                  "TO"i

--- a/evadb/parser/evadb.lark
+++ b/evadb/parser/evadb.lark
@@ -4,7 +4,7 @@
 // because we assume that inside the job, the user can specify multiple sql_statements
 // but not a create_job within a create_job.
 
-start: (sql_statement? ";")+ | (create_job ";")
+start: (sql_statement? ";")+ | (create_job ";") | (start_scheduler_statement ";")
 
 sql_statement: ddl_statement | dml_statement | utility_statement | context_statement
 
@@ -203,6 +203,8 @@ explain_statement: EXPLAIN explainable_statement
 
 explainable_statement : select_statement | insert_statement | update_statement | delete_statement | create_table
 
+start_scheduler_statement : START JOB_SCHEDULER
+
 // Context Statements
 
 use_statement: USE database_name "{" query_string "}" // One shortcoming that query string cannot have parenthesis
@@ -387,6 +389,7 @@ INDEX:                               "INDEX"i
 INSERT:                              "INSERT"i
 IS:                                  "IS"i
 JOB:                                 "JOB"i
+JOB_SCHEDULER:                       "JOB_SCHEDULER"i
 JOIN:                                "JOIN"i
 KEY:                                 "KEY"i
 LATERAL:                             "LATERAL"i

--- a/evadb/parser/lark_visitor/__init__.py
+++ b/evadb/parser/lark_visitor/__init__.py
@@ -35,6 +35,7 @@ from evadb.parser.lark_visitor._select_statement import Select
 from evadb.parser.lark_visitor._set_statement import Set
 from evadb.parser.lark_visitor._show_statements import Show
 from evadb.parser.lark_visitor._start_scheduler_statement import StartScheduler
+from evadb.parser.lark_visitor._stop_scheduler_statement import StopScheduler
 from evadb.parser.lark_visitor._table_sources import TableSources
 from evadb.parser.lark_visitor._use_statement import Use
 
@@ -83,6 +84,7 @@ class LarkInterpreter(
     Use,
     Set,
     StartScheduler,
+    StopScheduler,
 ):
     def __init__(self, query):
         super().__init__()

--- a/evadb/parser/lark_visitor/__init__.py
+++ b/evadb/parser/lark_visitor/__init__.py
@@ -34,6 +34,7 @@ from evadb.parser.lark_visitor._rename_statement import RenameTable
 from evadb.parser.lark_visitor._select_statement import Select
 from evadb.parser.lark_visitor._set_statement import Set
 from evadb.parser.lark_visitor._show_statements import Show
+from evadb.parser.lark_visitor._start_scheduler_statement import StartScheduler
 from evadb.parser.lark_visitor._table_sources import TableSources
 from evadb.parser.lark_visitor._use_statement import Use
 
@@ -81,6 +82,7 @@ class LarkInterpreter(
     Delete,
     Use,
     Set,
+    StartScheduler,
 ):
     def __init__(self, query):
         super().__init__()

--- a/evadb/parser/lark_visitor/_start_scheduler_statement.py
+++ b/evadb/parser/lark_visitor/_start_scheduler_statement.py
@@ -18,7 +18,7 @@ from evadb.parser.start_scheduler_statement import StartSchedulerStatement
 
 
 ##################################################################
-# START STATEMENT
+# START SCHEDULER STATEMENT
 ##################################################################
 class StartScheduler:
     def start_scheduler_statement(self, tree):

--- a/evadb/parser/lark_visitor/_start_scheduler_statement.py
+++ b/evadb/parser/lark_visitor/_start_scheduler_statement.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from lark.tree import Tree
+
+from evadb.parser.start_scheduler_statement import StartSchedulerStatement
+
+
+##################################################################
+# START STATEMENT
+##################################################################
+class StartScheduler:
+    def start_scheduler_statement(self, tree):
+        start_stmt = StartSchedulerStatement()
+        return start_stmt

--- a/evadb/parser/lark_visitor/_stop_scheduler_statement.py
+++ b/evadb/parser/lark_visitor/_stop_scheduler_statement.py
@@ -12,15 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import multiprocessing
-from evadb.database import EvaDBDatabase
-from evadb.executor.abstract_executor import AbstractExecutor
-from evadb.parser.start_scheduler_statement import StartSchedulerStatement
-from evadb.utils.logging_manager import logger
+from lark.tree import Tree
 
-class StartSchedulerExecutor(AbstractExecutor):
-    def __init__(self, db: EvaDBDatabase, node: StartSchedulerStatement):
-        super().__init__(db, node)
+from evadb.parser.stop_scheduler_statement import StopSchedulerStatement
 
-    def exec(self, *args, **kwargs):
-        logger.debug("No op for StartSchedulerExecutor")
+
+##################################################################
+# STOP SCHEDULER STATEMENT
+##################################################################
+class StopScheduler:
+    def stop_scheduler_statement(self, tree):
+        stop_stmt = StopSchedulerStatement()
+        return stop_stmt

--- a/evadb/parser/start_scheduler_statement.py
+++ b/evadb/parser/start_scheduler_statement.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Any
+
+from evadb.parser.statement import AbstractStatement
+from evadb.parser.types import StatementType
+
+
+class StartSchedulerStatement(AbstractStatement):
+    def __init__(self):
+        super().__init__(StatementType.START)
+
+    def __str__(self):
+        return "START JOB_SCHEDULER"
+
+    def __eq__(self, other):
+        if not isinstance(other, StartSchedulerStatement):
+            return False
+        return True
+    
+    def __hash__(self) -> int:
+        return super().__hash__()

--- a/evadb/parser/stop_scheduler_statement.py
+++ b/evadb/parser/stop_scheduler_statement.py
@@ -12,15 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import multiprocessing
-from evadb.database import EvaDBDatabase
-from evadb.executor.abstract_executor import AbstractExecutor
-from evadb.parser.start_scheduler_statement import StartSchedulerStatement
-from evadb.utils.logging_manager import logger
+from __future__ import annotations
 
-class StartSchedulerExecutor(AbstractExecutor):
-    def __init__(self, db: EvaDBDatabase, node: StartSchedulerStatement):
-        super().__init__(db, node)
+from typing import Any
 
-    def exec(self, *args, **kwargs):
-        logger.debug("No op for StartSchedulerExecutor")
+from evadb.parser.statement import AbstractStatement
+from evadb.parser.types import StatementType
+
+
+class StopSchedulerStatement(AbstractStatement):
+    def __init__(self):
+        super().__init__(StatementType.STOP)
+
+    def __str__(self):
+        return "STOP JOB_SCHEDULER"
+
+    def __eq__(self, other):
+        if not isinstance(other, StopSchedulerStatement):
+            return False
+        return True
+    
+    def __hash__(self) -> int:
+        return super().__hash__()

--- a/evadb/parser/types.py
+++ b/evadb/parser/types.py
@@ -44,6 +44,7 @@ class StatementType(EvaDBEnum):
     SET  # noqa: F821
     CREATE_JOB  # noqa: F821
     START # noqa: F821
+    STOP # noqa: F821
     # add other types
 
 

--- a/evadb/parser/types.py
+++ b/evadb/parser/types.py
@@ -43,6 +43,7 @@ class StatementType(EvaDBEnum):
     USE  # noqa: F821
     SET  # noqa: F821
     CREATE_JOB  # noqa: F821
+    START # noqa: F821
     # add other types
 
 

--- a/evadb/parser/utils.py
+++ b/evadb/parser/utils.py
@@ -28,6 +28,7 @@ from evadb.parser.select_statement import SelectStatement
 from evadb.parser.set_statement import SetStatement
 from evadb.parser.show_statement import ShowStatement
 from evadb.parser.start_scheduler_statement import StartSchedulerStatement
+from evadb.parser.stop_scheduler_statement import StopSchedulerStatement
 from evadb.parser.types import ObjectType
 from evadb.parser.use_statement import UseStatement
 
@@ -39,6 +40,7 @@ SKIP_BINDER_AND_OPTIMIZER_STATEMENTS = (
     UseStatement,
     SetStatement,
     StartSchedulerStatement,
+    StopSchedulerStatement,
 )
 
 

--- a/evadb/parser/utils.py
+++ b/evadb/parser/utils.py
@@ -27,6 +27,7 @@ from evadb.parser.rename_statement import RenameTableStatement
 from evadb.parser.select_statement import SelectStatement
 from evadb.parser.set_statement import SetStatement
 from evadb.parser.show_statement import ShowStatement
+from evadb.parser.start_scheduler_statement import StartSchedulerStatement
 from evadb.parser.types import ObjectType
 from evadb.parser.use_statement import UseStatement
 
@@ -37,6 +38,7 @@ SKIP_BINDER_AND_OPTIMIZER_STATEMENTS = (
     CreateJobStatement,
     UseStatement,
     SetStatement,
+    StartSchedulerStatement,
 )
 
 


### PR DESCRIPTION
Adding framework for START and STOP SQL-like statements to start and stop the job scheduler process. 

The start_scheduler_executor and stop_scheduler_executor are currently No-Ops since the current job scheduling design does not provide a straightforward way to start the scheduler process from within a query executor function.

Currently, the job scheduler process is started using a `connection` object. Hence the current functionality of starting jobs using `connection.start_jobs()`. This `start_jobs()` function cannot be re-used within the query executor since the connection object is not available at the executor level.