### PR TITLE
feat: Simplifying UDF definition

### DIFF
--- a/evadb/binder/function_expression_binder.py
+++ b/evadb/binder/function_expression_binder.py
@@ -29,6 +29,7 @@ from evadb.configuration.constants import EvaDB_INSTALLATION_DIR
 from evadb.executor.execution_context import Context
 from evadb.expression.function_expression import FunctionExpression
 from evadb.expression.tuple_value_expression import TupleValueExpression
+from evadb.functions.helpers.udf import UserDefinedFunction
 from evadb.parser.types import FunctionType
 from evadb.third_party.huggingface.binder import assign_hf_function
 from evadb.utils.generic_utils import (
@@ -118,10 +119,10 @@ def bind_func_expr(binder: StatementBinder, node: FunctionExpression):
                     )
                     properties["openai_api_key"] = openai_key
 
-            if inspect.isclass(function_class):
-                node.function = lambda: function_class(**properties)
-            else:
+            if isinstance(function_class, UserDefinedFunction):
                 node.function = function_class
+            else:
+                node.function = lambda: function_class(**properties)
         except Exception as e:
             err_msg = (
                 f"{str(e)}. Please verify that the function class name in the "

--- a/evadb/binder/function_expression_binder.py
+++ b/evadb/binder/function_expression_binder.py
@@ -28,7 +28,6 @@ from evadb.configuration.constants import EvaDB_INSTALLATION_DIR
 from evadb.executor.execution_context import Context
 from evadb.expression.function_expression import FunctionExpression
 from evadb.expression.tuple_value_expression import TupleValueExpression
-from evadb.functions.helpers.udf import UserDefinedFunction
 from evadb.parser.types import FunctionType
 from evadb.third_party.huggingface.binder import assign_hf_function
 from evadb.utils.generic_utils import string_comparison_case_insensitive
@@ -116,10 +115,7 @@ def bind_func_expr(binder: StatementBinder, node: FunctionExpression):
                     )
                     properties["openai_api_key"] = openai_key
 
-            if isinstance(function_class, UserDefinedFunction):
-                node.function = function_class
-            else:
-                node.function = lambda: function_class(**properties)
+            node.function = lambda: function_class(**properties)
         except Exception as e:
             err_msg = (
                 f"{str(e)}. Please verify that the function class name in the "

--- a/evadb/binder/function_expression_binder.py
+++ b/evadb/binder/function_expression_binder.py
@@ -31,9 +31,7 @@ from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.functions.helpers.udf import UserDefinedFunction
 from evadb.parser.types import FunctionType
 from evadb.third_party.huggingface.binder import assign_hf_function
-from evadb.utils.generic_utils import (
-    string_comparison_case_insensitive,
-)
+from evadb.utils.generic_utils import string_comparison_case_insensitive
 from evadb.utils.load_function_class_from_file import load_function_class_from_file
 from evadb.utils.logging_manager import logger
 

--- a/evadb/binder/function_expression_binder.py
+++ b/evadb/binder/function_expression_binder.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import inspect
 from pathlib import Path
 
 from evadb.binder.binder_utils import (

--- a/evadb/binder/function_expression_binder.py
+++ b/evadb/binder/function_expression_binder.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import inspect
 from pathlib import Path
 
 from evadb.binder.binder_utils import (
@@ -31,9 +32,9 @@ from evadb.expression.tuple_value_expression import TupleValueExpression
 from evadb.parser.types import FunctionType
 from evadb.third_party.huggingface.binder import assign_hf_function
 from evadb.utils.generic_utils import (
-    load_function_class_from_file,
     string_comparison_case_insensitive,
 )
+from evadb.utils.load_function_class_from_file import load_function_class_from_file
 from evadb.utils.logging_manager import logger
 
 
@@ -117,7 +118,10 @@ def bind_func_expr(binder: StatementBinder, node: FunctionExpression):
                     )
                     properties["openai_api_key"] = openai_key
 
-            node.function = lambda: function_class(**properties)
+            if inspect.isclass(function_class):
+                node.function = lambda: function_class(**properties)
+            else:
+                node.function = function_class
         except Exception as e:
             err_msg = (
                 f"{str(e)}. Please verify that the function class name in the "

--- a/evadb/catalog/catalog_type.py
+++ b/evadb/catalog/catalog_type.py
@@ -74,6 +74,23 @@ class NdArrayType(EvaDBEnum):
     ANYTYPE  # noqa: F821
 
     @classmethod
+    def from_python_type(cls, t):
+        from decimal import Decimal
+
+        if t == int:
+            return cls.INT64
+        elif t == str:
+            return cls.STR
+        elif t == bool:
+            return cls.BOOL
+        elif t == float:
+            return cls.FLOAT64
+        elif t == Decimal:
+            return cls.DECIMAL
+        else:
+            return cls.ANYTYPE
+
+    @classmethod
     def to_numpy_type(cls, t):
         from decimal import Decimal
 

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -40,7 +40,6 @@ from evadb.configuration.constants import (
 from evadb.database import EvaDBDatabase
 from evadb.executor.abstract_executor import AbstractExecutor
 from evadb.functions.decorators.utils import load_io_from_function_decorators
-from evadb.functions.helpers.udf import UserDefinedFunction
 from evadb.models.storage.batch import Batch
 from evadb.plan_nodes.create_function_plan import CreateFunctionPlan
 from evadb.third_party.huggingface.create import gen_hf_io_catalog_entries
@@ -853,8 +852,7 @@ class CreateFunctionExecutor(AbstractExecutor):
             # loading the function class from the file
             function = load_function_class_from_file(impl_path, self.node.name)
             # initializing the function class calls the setup method internally
-            if not isinstance(function, UserDefinedFunction):
-                function(**function_args)
+            function(**function_args)
         except Exception as e:
             err_msg = f"Error creating function {self.node.name}: {str(e)}"
             # logger.error(err_msg)

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import contextlib
 import hashlib
+import locale
 import os
 import pickle
 import re

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -41,6 +41,7 @@ from evadb.configuration.constants import (
 from evadb.database import EvaDBDatabase
 from evadb.executor.abstract_executor import AbstractExecutor
 from evadb.functions.decorators.utils import load_io_from_function_decorators
+from evadb.functions.helpers.udf import UserDefinedFunction
 from evadb.models.storage.batch import Batch
 from evadb.plan_nodes.create_function_plan import CreateFunctionPlan
 from evadb.third_party.huggingface.create import gen_hf_io_catalog_entries
@@ -853,7 +854,7 @@ class CreateFunctionExecutor(AbstractExecutor):
             # loading the function class from the file
             function = load_function_class_from_file(impl_path, self.node.name)
             # initializing the function class calls the setup method internally
-            if inspect.isclass(function):
+            if not isinstance(function, UserDefinedFunction):
                 function(**function_args)
         except Exception as e:
             err_msg = f"Error creating function {self.node.name}: {str(e)}"

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import contextlib
 import hashlib
+import inspect
 import locale
 import os
 import pickle
@@ -45,7 +46,6 @@ from evadb.plan_nodes.create_function_plan import CreateFunctionPlan
 from evadb.third_party.huggingface.create import gen_hf_io_catalog_entries
 from evadb.utils.errors import FunctionIODefinitionError
 from evadb.utils.generic_utils import (
-    load_function_class_from_file,
     string_comparison_case_insensitive,
     try_to_import_flaml_automl,
     try_to_import_ludwig,
@@ -54,6 +54,7 @@ from evadb.utils.generic_utils import (
     try_to_import_torch,
     try_to_import_ultralytics,
 )
+from evadb.utils.load_function_class_from_file import load_function_class_from_file
 from evadb.utils.logging_manager import logger
 
 
@@ -852,7 +853,8 @@ class CreateFunctionExecutor(AbstractExecutor):
             # loading the function class from the file
             function = load_function_class_from_file(impl_path, self.node.name)
             # initializing the function class calls the setup method internally
-            function(**function_args)
+            if inspect.isclass(function):
+                function(**function_args)
         except Exception as e:
             err_msg = f"Error creating function {self.node.name}: {str(e)}"
             # logger.error(err_msg)

--- a/evadb/executor/create_function_executor.py
+++ b/evadb/executor/create_function_executor.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 import contextlib
 import hashlib
-import inspect
-import locale
 import os
 import pickle
 import re

--- a/evadb/expression/function_expression.py
+++ b/evadb/expression/function_expression.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
+import inspect
 from typing import Callable, List, Tuple
 
 import numpy as np
@@ -163,7 +164,10 @@ class FunctionExpression(AbstractExpression):
 
     def _gpu_enabled_function(self):
         if self._function_instance is None:
-            self._function_instance = self.function()
+            if inspect.isclass(self.function):
+                self._function_instance = self.function()
+            else:
+                self._function_instance = self.function
             if isinstance(self._function_instance, GPUCompatible):
                 device = self._context.gpu_device()
                 if device != NO_GPU:

--- a/evadb/expression/function_expression.py
+++ b/evadb/expression/function_expression.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-import inspect
 from typing import Callable, List, Tuple
 
 import numpy as np

--- a/evadb/expression/function_expression.py
+++ b/evadb/expression/function_expression.py
@@ -25,6 +25,7 @@ from evadb.constants import NO_GPU
 from evadb.executor.execution_context import Context
 from evadb.expression.abstract_expression import AbstractExpression, ExpressionType
 from evadb.functions.gpu_compatible import GPUCompatible
+from evadb.functions.helpers.udf import UserDefinedFunction
 from evadb.models.storage.batch import Batch
 from evadb.parser.alias import Alias
 from evadb.utils.kv_cache import DiskKVCache
@@ -164,10 +165,10 @@ class FunctionExpression(AbstractExpression):
 
     def _gpu_enabled_function(self):
         if self._function_instance is None:
-            if inspect.isclass(self.function):
-                self._function_instance = self.function()
-            else:
+            if isinstance(self.function, UserDefinedFunction):
                 self._function_instance = self.function
+            else:
+                self._function_instance = self.function()
             if isinstance(self._function_instance, GPUCompatible):
                 device = self._context.gpu_device()
                 if device != NO_GPU:

--- a/evadb/expression/function_expression.py
+++ b/evadb/expression/function_expression.py
@@ -24,7 +24,6 @@ from evadb.constants import NO_GPU
 from evadb.executor.execution_context import Context
 from evadb.expression.abstract_expression import AbstractExpression, ExpressionType
 from evadb.functions.gpu_compatible import GPUCompatible
-from evadb.functions.helpers.udf import UserDefinedFunction
 from evadb.models.storage.batch import Batch
 from evadb.parser.alias import Alias
 from evadb.utils.kv_cache import DiskKVCache
@@ -164,10 +163,7 @@ class FunctionExpression(AbstractExpression):
 
     def _gpu_enabled_function(self):
         if self._function_instance is None:
-            if isinstance(self.function, UserDefinedFunction):
-                self._function_instance = self.function
-            else:
-                self._function_instance = self.function()
+            self._function_instance = self.function()
             if isinstance(self._function_instance, GPUCompatible):
                 device = self._context.gpu_device()
                 if device != NO_GPU:

--- a/evadb/functions/helpers/udf.py
+++ b/evadb/functions/helpers/udf.py
@@ -48,11 +48,12 @@ class UserDefinedFunction(AbstractFunction):
         )
 
         output_io_arg = PandasDataframe(
-            columns=[self.name],
+            columns=[self.name.lower()],
             column_types=[NdArrayType.from_python_type(self._output)],
             column_shapes=[(1,)],
         )
 
+        # set the input and output tags (similar to @forward decorator)
         self.forward.tags["input"] = [input_io_arg]
         self.forward.tags["output"] = [output_io_arg]
 
@@ -62,11 +63,8 @@ class UserDefinedFunction(AbstractFunction):
     )
     def forward(self, in_df: pd.DataFrame):
         out_df = pd.DataFrame()
-
-        for inp in self._inputs:
-            assert inp.name in in_df.columns
-
-        out_df[self.name] = in_df.apply(self._func, axis=1)
+        # apply the function to each row
+        out_df[self.name.lower()] = in_df.apply(self._func, axis=1)
 
         return out_df
     

--- a/evadb/functions/helpers/udf.py
+++ b/evadb/functions/helpers/udf.py
@@ -1,0 +1,75 @@
+import ast
+import types
+
+import os
+
+import pandas as pd
+
+from evadb.catalog.catalog_type import NdArrayType
+from evadb.functions.abstract.abstract_function import AbstractFunction
+from evadb.functions.decorators.decorators import forward, setup
+from evadb.functions.decorators.io_descriptors.data_types import PandasDataframe
+
+class UserDefinedFunction(AbstractFunction):
+    """
+    Arguments:
+
+    Input Signatures:
+        id (int)
+
+    Output Signatures:
+        output (int)
+    """
+
+    @property
+    def name(self) -> str:
+        return self._func.__name__
+
+    @setup(cacheable=True, batchable=True)
+    def setup(
+        self
+    ) -> None:
+        import inspect 
+        sig = inspect.signature(self._func)
+        params = sig.parameters
+        # assert that all params have a type annotation
+        for param in params.values():
+            assert param.annotation != inspect.Parameter.empty, f"Parameter {param.name} has no type annotation"
+        self._inputs = list(params.values())
+        # get the return type annotation
+        self._output = sig.return_annotation
+        # assert that the return type annotation is not empty
+        assert self._output != inspect.Parameter.empty, "Return type annotation is empty"
+
+        input_io_arg = PandasDataframe(
+            columns=[x.name for x in self._inputs],
+            column_types=[NdArrayType.from_python_type(x.annotation) for x in self._inputs],
+            column_shapes=[(1,) for x in self._inputs]
+        )
+
+        output_io_arg = PandasDataframe(
+            columns=[self.name],
+            column_types=[NdArrayType.from_python_type(self._output)],
+            column_shapes=[(1,)],
+        )
+
+        self.forward.tags["input"] = [input_io_arg]
+        self.forward.tags["output"] = [output_io_arg]
+
+    @forward(
+        input_signatures=[],
+        output_signatures=[],
+    )
+    def forward(self, in_df: pd.DataFrame):
+        out_df = pd.DataFrame()
+
+        for inp in self._inputs:
+            assert inp.name in in_df.columns
+
+        out_df[self.name] = in_df.apply(self._func, axis=1)
+
+        return out_df
+    
+    def __init__(self, inner_func: callable, **kwargs):
+        self._func = inner_func
+        super().__init__()

--- a/evadb/functions/helpers/udf.py
+++ b/evadb/functions/helpers/udf.py
@@ -1,9 +1,24 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import pandas as pd
 
 from evadb.catalog.catalog_type import NdArrayType
 from evadb.functions.abstract.abstract_function import AbstractFunction
 from evadb.functions.decorators.decorators import forward, setup
 from evadb.functions.decorators.io_descriptors.data_types import PandasDataframe
+
 
 class UserDefinedFunction(AbstractFunction):
     """
@@ -21,25 +36,30 @@ class UserDefinedFunction(AbstractFunction):
         return self._func.__name__
 
     @setup(cacheable=True, batchable=True)
-    def setup(
-        self
-    ) -> None:
-        import inspect 
+    def setup(self) -> None:
+        import inspect
+
         sig = inspect.signature(self._func)
         params = sig.parameters
         # assert that all params have a type annotation
         for param in params.values():
-            assert param.annotation != inspect.Parameter.empty, f"Parameter {param.name} has no type annotation"
+            assert (
+                param.annotation != inspect.Parameter.empty
+            ), f"Parameter {param.name} has no type annotation"
         self._inputs = list(params.values())
         # get the return type annotation
         self._output = sig.return_annotation
         # assert that the return type annotation is not empty
-        assert self._output != inspect.Parameter.empty, "Return type annotation is empty"
+        assert (
+            self._output != inspect.Parameter.empty
+        ), "Return type annotation is empty"
 
         input_io_arg = PandasDataframe(
             columns=[x.name for x in self._inputs],
-            column_types=[NdArrayType.from_python_type(x.annotation) for x in self._inputs],
-            column_shapes=[(1,) for x in self._inputs]
+            column_types=[
+                NdArrayType.from_python_type(x.annotation) for x in self._inputs
+            ],
+            column_shapes=[(1,) for x in self._inputs],
         )
 
         output_io_arg = PandasDataframe(
@@ -62,7 +82,7 @@ class UserDefinedFunction(AbstractFunction):
         out_df[self.name.lower()] = in_df.apply(self._func, axis=1)
 
         return out_df
-    
+
     def __init__(self, inner_func: callable, **kwargs):
         self._func = inner_func
         super().__init__()

--- a/evadb/functions/helpers/udf.py
+++ b/evadb/functions/helpers/udf.py
@@ -1,8 +1,3 @@
-import ast
-import types
-
-import os
-
 import pandas as pd
 
 from evadb.catalog.catalog_type import NdArrayType

--- a/evadb/functions/helpers/udf.py
+++ b/evadb/functions/helpers/udf.py
@@ -83,6 +83,9 @@ class UserDefinedFunction(AbstractFunction):
 
         return out_df
 
-    def __init__(self, inner_func: callable, **kwargs):
-        self._func = inner_func
-        super().__init__()
+
+def generate_udf(func):
+    class_body = {
+        "_func": staticmethod(func),
+    }
+    return type(func.__name__, (UserDefinedFunction,), class_body)

--- a/evadb/utils/generic_utils.py
+++ b/evadb/utils/generic_utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import hashlib
 import importlib
-import inspect
 import os
 import pickle
 import shutil
@@ -61,57 +60,6 @@ def str_to_class(class_path: str):
     module_path, class_name = class_path.rsplit(".", 1)
     module = importlib.import_module(module_path)
     return getattr(module, class_name)
-
-
-def load_function_class_from_file(filepath, classname=None):
-    """
-    Load a class from a Python file. If the classname is not specified, the function will check if there is only one class in the file and load that. If there are multiple classes, it will raise an error.
-
-    Args:
-        filepath (str): The path to the Python file.
-        classname (str, optional): The name of the class to load. If not specified, the function will try to load a class with the same name as the file. Defaults to None.
-
-    Returns:
-        The class instance.
-
-    Raises:
-        ImportError: If the module cannot be loaded.
-        FileNotFoundError: If the file cannot be found.
-        RuntimeError: Any othe type of runtime error.
-    """
-    try:
-        abs_path = Path(filepath).resolve()
-        spec = importlib.util.spec_from_file_location(abs_path.stem, abs_path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-    except ImportError as e:
-        # ImportError in the case when we are able to find the file but not able to load the module
-        err_msg = f"ImportError : Couldn't load function from {filepath} : {str(e)}. Not able to load the code provided in the file {abs_path}. Please ensure that the file contains the implementation code for the function."
-        raise ImportError(err_msg)
-    except FileNotFoundError as e:
-        # FileNotFoundError in the case when we are not able to find the file at all at the path.
-        err_msg = f"FileNotFoundError : Couldn't load function from {filepath} : {str(e)}. This might be because the function implementation file does not exist. Please ensure the file exists at {abs_path}"
-        raise FileNotFoundError(err_msg)
-    except Exception as e:
-        # Default exception, we don't know what exactly went wrong so we just output the error message
-        err_msg = f"Couldn't load function from {filepath} : {str(e)}."
-        raise RuntimeError(err_msg)
-
-    # Try to load the specified class by name
-    if classname and hasattr(module, classname):
-        return getattr(module, classname)
-
-    # If class name not specified, check if there is only one class in the file
-    classes = [
-        obj
-        for _, obj in inspect.getmembers(module, inspect.isclass)
-        if obj.__module__ == module.__name__
-    ]
-    if len(classes) != 1:
-        raise ImportError(
-            f"{filepath} contains {len(classes)} classes, please specify the correct class to load by naming the function with the same name in the CREATE query."
-        )
-    return classes[0]
 
 
 def is_gpu_available() -> bool:

--- a/evadb/utils/load_function_class_from_file.py
+++ b/evadb/utils/load_function_class_from_file.py
@@ -1,0 +1,64 @@
+from evadb.functions.helpers.udf import UserDefinedFunction
+
+
+import importlib
+import inspect
+from pathlib import Path
+
+
+def load_function_class_from_file(filepath, classname=None):
+    """
+    Load a class from a Python file. If the classname is not specified, the function will check if there is only one class in the file and load that. If there are multiple classes, it will raise an error.
+
+    Args:
+        filepath (str): The path to the Python file.
+        classname (str, optional): The name of the class to load. If not specified, the function will try to load a class with the same name as the file. Defaults to None.
+
+    Returns:
+        The class instance.
+
+    Raises:
+        ImportError: If the module cannot be loaded.
+        FileNotFoundError: If the file cannot be found.
+        RuntimeError: Any othe type of runtime error.
+    """
+    try:
+        abs_path = Path(filepath).resolve()
+        spec = importlib.util.spec_from_file_location(abs_path.stem, abs_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except ImportError as e:
+        # ImportError in the case when we are able to find the file but not able to load the module
+        err_msg = f"ImportError : Couldn't load function from {filepath} : {str(e)}. Not able to load the code provided in the file {abs_path}. Please ensure that the file contains the implementation code for the function."
+        raise ImportError(err_msg)
+    except FileNotFoundError as e:
+        # FileNotFoundError in the case when we are not able to find the file at all at the path.
+        err_msg = f"FileNotFoundError : Couldn't load function from {filepath} : {str(e)}. This might be because the function implementation file does not exist. Please ensure the file exists at {abs_path}"
+        raise FileNotFoundError(err_msg)
+    except Exception as e:
+        # Default exception, we don't know what exactly went wrong so we just output the error message
+        err_msg = f"Couldn't load function from {filepath} : {str(e)}."
+        raise RuntimeError(err_msg)
+
+    # Try to load the specified class by name
+    if classname and hasattr(module, classname):
+        obj = getattr(module, classname)
+        if not inspect.isclass(obj):
+            return UserDefinedFunction(obj)
+        return obj
+
+    # If class name not specified, check if there is only one class in the file
+    classes = [
+        obj
+        for _, obj in inspect.getmembers(module, inspect.isclass)
+        if obj.__module__ == module.__name__
+    ]
+    if len(classes) != 1:
+        raise ImportError(
+            f"{filepath} contains {len(classes)} classes, please specify the correct class to load by naming the function with the same name in the CREATE query."
+        )
+
+    if not inspect.isclass(classes[0]):
+        return UserDefinedFunction(classes[0])
+
+    return classes[0]

--- a/evadb/utils/load_function_class_from_file.py
+++ b/evadb/utils/load_function_class_from_file.py
@@ -54,11 +54,15 @@ def load_function_class_from_file(filepath, classname=None):
         if obj.__module__ == module.__name__
     ]
     if len(classes) != 1:
+        functions = [
+            obj
+            for _, obj in inspect.getmembers(module, inspect.isfunction)
+            if obj.__module__ == module.__name__
+        ]
+        if len(functions) == 1:
+            return UserDefinedFunction(functions[0])
         raise ImportError(
             f"{filepath} contains {len(classes)} classes, please specify the correct class to load by naming the function with the same name in the CREATE query."
         )
-
-    if not inspect.isclass(classes[0]):
-        return UserDefinedFunction(classes[0])
-
+    
     return classes[0]

--- a/evadb/utils/load_function_class_from_file.py
+++ b/evadb/utils/load_function_class_from_file.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from evadb.functions.helpers.udf import UserDefinedFunction
 
 
@@ -64,5 +78,5 @@ def load_function_class_from_file(filepath, classname=None):
         raise ImportError(
             f"{filepath} contains {len(classes)} classes, please specify the correct class to load by naming the function with the same name in the CREATE query."
         )
-    
+
     return classes[0]

--- a/evadb/utils/load_function_class_from_file.py
+++ b/evadb/utils/load_function_class_from_file.py
@@ -16,7 +16,7 @@ import importlib
 import inspect
 from pathlib import Path
 
-from evadb.functions.helpers.udf import UserDefinedFunction
+from evadb.functions.helpers.udf import generate_udf
 
 
 def load_function_class_from_file(filepath, classname=None):
@@ -57,7 +57,7 @@ def load_function_class_from_file(filepath, classname=None):
     if classname and hasattr(module, classname):
         obj = getattr(module, classname)
         if not inspect.isclass(obj):
-            return UserDefinedFunction(obj)
+            return generate_udf(obj)
         return obj
 
     # If class name not specified, check if there is only one class in the file
@@ -73,7 +73,7 @@ def load_function_class_from_file(filepath, classname=None):
             if obj.__module__ == module.__name__
         ]
         if len(functions) == 1:
-            return UserDefinedFunction(functions[0])
+            return generate_udf(functions[0])
         raise ImportError(
             f"{filepath} contains {len(classes)} classes, please specify the correct class to load by naming the function with the same name in the CREATE query."
         )

--- a/evadb/utils/load_function_class_from_file.py
+++ b/evadb/utils/load_function_class_from_file.py
@@ -12,12 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from evadb.functions.helpers.udf import UserDefinedFunction
-
-
 import importlib
 import inspect
 from pathlib import Path
+
+from evadb.functions.helpers.udf import UserDefinedFunction
 
 
 def load_function_class_from_file(filepath, classname=None):

--- a/test/integration_tests/short/test_generic_utils.py
+++ b/test/integration_tests/short/test_generic_utils.py
@@ -25,7 +25,8 @@ from evadb.utils.generic_utils import (
     str_to_class,
     validate_kwargs,
 )
-import evadb.utils.load_function_class_from_file as load_function_class_from_file
+
+from evadb.utils.load_function_class_from_file import load_function_class_from_file
 
 
 class ModulePathTest(unittest.TestCase):

--- a/test/integration_tests/short/test_generic_utils.py
+++ b/test/integration_tests/short/test_generic_utils.py
@@ -25,7 +25,6 @@ from evadb.utils.generic_utils import (
     str_to_class,
     validate_kwargs,
 )
-
 from evadb.utils.load_function_class_from_file import load_function_class_from_file
 
 

--- a/test/integration_tests/short/test_generic_utils.py
+++ b/test/integration_tests/short/test_generic_utils.py
@@ -22,10 +22,10 @@ from evadb.readers.decord_reader import DecordReader
 from evadb.utils.generic_utils import (
     generate_file_path,
     is_gpu_available,
-    load_function_class_from_file,
     str_to_class,
     validate_kwargs,
 )
+import evadb.utils.load_function_class_from_file as load_function_class_from_file
 
 
 class ModulePathTest(unittest.TestCase):

--- a/test/integration_tests/short/test_simple_udf.py
+++ b/test/integration_tests/short/test_simple_udf.py
@@ -12,11 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 import os
-import pandas as pd
 import tempfile
+import unittest
 from test.util import get_evadb_for_testing
+
+import pandas as pd
 
 from evadb.server.command_handler import execute_query_fetch_all
 

--- a/test/integration_tests/short/test_simple_udf.py
+++ b/test/integration_tests/short/test_simple_udf.py
@@ -1,0 +1,56 @@
+import unittest
+import os
+import pandas as pd
+import tempfile
+from test.util import get_evadb_for_testing, shutdown_ray
+
+from evadb.executor.executor_utils import ExecutorError
+from evadb.server.command_handler import execute_query_fetch_all
+
+class SimpleUDFTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.evadb = get_evadb_for_testing()
+        cls.evadb.catalog().reset()
+    
+    def setUp(self):
+        fd, self.temp_path = tempfile.mkstemp(suffix=".py")
+        # Create a python file with two functions
+        with os.fdopen(fd, "w") as f:
+            f.write("def mod5(id:int)->int:\n")
+            f.write("\treturn id % 5\n")
+            f.write("\n")
+            f.write("def isEven(id:int)->bool:\n")
+            f.write("\treturn id % 2 == 0\n")
+        # Create a table with 10 rows
+        execute_query_fetch_all(self.evadb, "CREATE TABLE IF NOT EXISTS test (id INTEGER);")
+        for i in range(10):
+            execute_query_fetch_all(self.evadb, f"INSERT INTO test (id) VALUES ({i});")     
+    
+    def tearDown(self):
+        # Delete the python file
+        os.remove(self.temp_path)
+        # Delete the table
+        execute_query_fetch_all(self.evadb, "DROP TABLE test;")
+
+    def test_first_udf(self):
+        # Create the UDF
+        execute_query_fetch_all(self.evadb, f"CREATE FUNCTION mod5 IMPL '{self.temp_path}';")
+        # Query the UDF
+        result = execute_query_fetch_all(self.evadb, "SELECT mod5(id) FROM test;")
+        expected = pd.DataFrame({"mod5.mod5": [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]})
+        # Check the result
+        self.assertTrue(result.frames.equals(expected))
+        # Delete the UDF
+        execute_query_fetch_all(self.evadb, "DROP FUNCTION mod5;")
+    
+    def test_second_udf(self):
+        # Create the UDF
+        execute_query_fetch_all(self.evadb, f"CREATE FUNCTION isEven IMPL '{self.temp_path}';")
+        # Query the UDF
+        result = execute_query_fetch_all(self.evadb, "SELECT isEven(id) FROM test;")
+        expected = pd.DataFrame({"iseven.iseven": [i % 2 == 0 for i in range(10)]})
+        # Check the result
+        self.assertEqual(result.frames.equals(expected), True)
+        # Delete the UDF
+        execute_query_fetch_all(self.evadb, "DROP FUNCTION isEven;")

--- a/test/integration_tests/short/test_simple_udf.py
+++ b/test/integration_tests/short/test_simple_udf.py
@@ -2,9 +2,8 @@ import unittest
 import os
 import pandas as pd
 import tempfile
-from test.util import get_evadb_for_testing, shutdown_ray
+from test.util import get_evadb_for_testing
 
-from evadb.executor.executor_utils import ExecutorError
 from evadb.server.command_handler import execute_query_fetch_all
 
 class SimpleUDFTest(unittest.TestCase):
@@ -13,15 +12,20 @@ class SimpleUDFTest(unittest.TestCase):
         cls.evadb = get_evadb_for_testing()
         cls.evadb.catalog().reset()
     
+    def write_udf_mod5(self, f):
+        f.write("def mod5(id:int)->int:\n")
+        f.write("\treturn id % 5\n")
+    
+    def write_udf_isEven(self, f):
+        f.write("def isEven(id:int)->bool:\n")
+        f.write("\treturn id % 2 == 0\n")
+
     def setUp(self):
         fd, self.temp_path = tempfile.mkstemp(suffix=".py")
         # Create a python file with two functions
         with os.fdopen(fd, "w") as f:
-            f.write("def mod5(id:int)->int:\n")
-            f.write("\treturn id % 5\n")
-            f.write("\n")
-            f.write("def isEven(id:int)->bool:\n")
-            f.write("\treturn id % 2 == 0\n")
+            self.write_udf_mod5(f)
+            self.write_udf_isEven(f)
         # Create a table with 10 rows
         execute_query_fetch_all(self.evadb, "CREATE TABLE IF NOT EXISTS test (id INTEGER);")
         for i in range(10):
@@ -54,3 +58,22 @@ class SimpleUDFTest(unittest.TestCase):
         self.assertEqual(result.frames.equals(expected), True)
         # Delete the UDF
         execute_query_fetch_all(self.evadb, "DROP FUNCTION isEven;")
+
+    def test_udf_name_missing(self):
+        # Create the UDF
+        with self.assertRaises(Exception):
+            execute_query_fetch_all(self.evadb, f"CREATE FUNCTION temp IMPL '{self.temp_path}';")
+    
+    def test_udf_single_function(self):
+        # rewrite the file to have only one function
+        with open(self.temp_path, "w") as f:
+            self.write_udf_mod5(f)
+        # Create the UDF
+        execute_query_fetch_all(self.evadb, f"CREATE FUNCTION mod_five IMPL '{self.temp_path}';")
+        # Query the UDF
+        result = execute_query_fetch_all(self.evadb, "SELECT mod_five(id) FROM test;")
+        expected = pd.DataFrame({"mod_five.mod5": [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]})
+        # Check the result
+        self.assertTrue(result.frames.equals(expected))
+        # Delete the UDF
+        execute_query_fetch_all(self.evadb, "DROP FUNCTION mod_five;")

--- a/test/integration_tests/short/test_simple_udf.py
+++ b/test/integration_tests/short/test_simple_udf.py
@@ -1,3 +1,17 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import unittest
 import os
 import pandas as pd
@@ -6,16 +20,17 @@ from test.util import get_evadb_for_testing
 
 from evadb.server.command_handler import execute_query_fetch_all
 
+
 class SimpleUDFTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.evadb = get_evadb_for_testing()
         cls.evadb.catalog().reset()
-    
+
     def write_udf_mod5(self, f):
         f.write("def mod5(id:int)->int:\n")
         f.write("\treturn id % 5\n")
-    
+
     def write_udf_isEven(self, f):
         f.write("def isEven(id:int)->bool:\n")
         f.write("\treturn id % 2 == 0\n")
@@ -27,10 +42,12 @@ class SimpleUDFTest(unittest.TestCase):
             self.write_udf_mod5(f)
             self.write_udf_isEven(f)
         # Create a table with 10 rows
-        execute_query_fetch_all(self.evadb, "CREATE TABLE IF NOT EXISTS test (id INTEGER);")
+        execute_query_fetch_all(
+            self.evadb, "CREATE TABLE IF NOT EXISTS test (id INTEGER);"
+        )
         for i in range(10):
-            execute_query_fetch_all(self.evadb, f"INSERT INTO test (id) VALUES ({i});")     
-    
+            execute_query_fetch_all(self.evadb, f"INSERT INTO test (id) VALUES ({i});")
+
     def tearDown(self):
         # Delete the python file
         os.remove(self.temp_path)
@@ -39,7 +56,9 @@ class SimpleUDFTest(unittest.TestCase):
 
     def test_first_udf(self):
         # Create the UDF
-        execute_query_fetch_all(self.evadb, f"CREATE FUNCTION mod5 IMPL '{self.temp_path}';")
+        execute_query_fetch_all(
+            self.evadb, f"CREATE FUNCTION mod5 IMPL '{self.temp_path}';"
+        )
         # Query the UDF
         result = execute_query_fetch_all(self.evadb, "SELECT mod5(id) FROM test;")
         expected = pd.DataFrame({"mod5.mod5": [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]})
@@ -47,10 +66,12 @@ class SimpleUDFTest(unittest.TestCase):
         self.assertTrue(result.frames.equals(expected))
         # Delete the UDF
         execute_query_fetch_all(self.evadb, "DROP FUNCTION mod5;")
-    
+
     def test_second_udf(self):
         # Create the UDF
-        execute_query_fetch_all(self.evadb, f"CREATE FUNCTION isEven IMPL '{self.temp_path}';")
+        execute_query_fetch_all(
+            self.evadb, f"CREATE FUNCTION isEven IMPL '{self.temp_path}';"
+        )
         # Query the UDF
         result = execute_query_fetch_all(self.evadb, "SELECT isEven(id) FROM test;")
         expected = pd.DataFrame({"iseven.iseven": [i % 2 == 0 for i in range(10)]})
@@ -62,14 +83,18 @@ class SimpleUDFTest(unittest.TestCase):
     def test_udf_name_missing(self):
         # Create the UDF
         with self.assertRaises(Exception):
-            execute_query_fetch_all(self.evadb, f"CREATE FUNCTION temp IMPL '{self.temp_path}';")
-    
+            execute_query_fetch_all(
+                self.evadb, f"CREATE FUNCTION temp IMPL '{self.temp_path}';"
+            )
+
     def test_udf_single_function(self):
         # rewrite the file to have only one function
         with open(self.temp_path, "w") as f:
             self.write_udf_mod5(f)
         # Create the UDF
-        execute_query_fetch_all(self.evadb, f"CREATE FUNCTION mod_five IMPL '{self.temp_path}';")
+        execute_query_fetch_all(
+            self.evadb, f"CREATE FUNCTION mod_five IMPL '{self.temp_path}';"
+        )
         # Query the UDF
         result = execute_query_fetch_all(self.evadb, "SELECT mod_five(id) FROM test;")
         expected = pd.DataFrame({"mod_five.mod5": [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]})

--- a/test/unit_tests/functions/test_abstract_udf.py
+++ b/test/unit_tests/functions/test_abstract_udf.py
@@ -21,8 +21,8 @@ from test.util import get_all_subclasses, get_mock_object
 import evadb
 from evadb.functions.abstract.abstract_function import AbstractFunction
 from evadb.functions.abstract.hf_abstract_function import AbstractHFFunction
-from evadb.functions.yolo_object_detector import Yolo
 from evadb.functions.helpers.udf import UserDefinedFunction
+from evadb.functions.yolo_object_detector import Yolo
 
 
 class AbstractFunctionTest(unittest.TestCase):
@@ -35,7 +35,10 @@ class AbstractFunctionTest(unittest.TestCase):
                 continue
             # if class is UserDefinedFunction
             if issubclass(derived_function_class, UserDefinedFunction):
-                temp_fun = lambda x: x
+
+                def temp_fun(x: int) -> int:
+                    return x
+
                 dummy_object = UserDefinedFunction(temp_fun)
                 self.assertTrue(str(dummy_object.name) is not None)
                 continue

--- a/test/unit_tests/functions/test_abstract_udf.py
+++ b/test/unit_tests/functions/test_abstract_udf.py
@@ -22,6 +22,7 @@ import evadb
 from evadb.functions.abstract.abstract_function import AbstractFunction
 from evadb.functions.abstract.hf_abstract_function import AbstractHFFunction
 from evadb.functions.yolo_object_detector import Yolo
+from evadb.functions.helpers.udf import UserDefinedFunction
 
 
 class AbstractFunctionTest(unittest.TestCase):
@@ -32,6 +33,13 @@ class AbstractFunctionTest(unittest.TestCase):
             # skip yolo and HF to avoid downloading model
             if issubclass(derived_function_class, (Yolo, AbstractHFFunction)):
                 continue
+            # if class is UserDefinedFunction
+            if issubclass(derived_function_class, UserDefinedFunction):
+                temp_fun = lambda x: x
+                dummy_object = UserDefinedFunction(temp_fun)
+                self.assertTrue(str(dummy_object.name) is not None)
+                continue
+
             if isabstract(derived_function_class) is False:
                 class_type = derived_function_class
                 # Check class init signature

--- a/test/unit_tests/functions/test_abstract_udf.py
+++ b/test/unit_tests/functions/test_abstract_udf.py
@@ -21,7 +21,7 @@ from test.util import get_all_subclasses, get_mock_object
 import evadb
 from evadb.functions.abstract.abstract_function import AbstractFunction
 from evadb.functions.abstract.hf_abstract_function import AbstractHFFunction
-from evadb.functions.helpers.udf import UserDefinedFunction
+from evadb.functions.helpers.udf import UserDefinedFunction, generate_udf
 from evadb.functions.yolo_object_detector import Yolo
 
 
@@ -39,7 +39,7 @@ class AbstractFunctionTest(unittest.TestCase):
                 def temp_fun(x: int) -> int:
                     return x
 
-                dummy_object = UserDefinedFunction(temp_fun)
+                dummy_object = generate_udf(temp_fun)()
                 self.assertTrue(str(dummy_object.name) is not None)
                 continue
 


### PR DESCRIPTION
# Problem
- Currently declaring UDFs is not simple, requiring a lot of boilerplate code, and obtuse input and output data types ([example](https://github.com/Prakhar314/evadb/blob/staging/evadb/functions/chatgpt.py#L94-L116))
- Snowflake has a simple interface for UDFs ([example](https://docs.snowflake.com/en/developer-guide/snowpark/python/creating-udfs#creating-a-udf-from-a-python-source-file)), we could use.
# Solution
- Modify `load_function_class_from_file` to handle regular python functions.
- Now, if the required instance is a Python function instead of a class extending `AbstractFunction`, we create a `UserDefinedFunction`, which is an instance of `AbstractFunction`, to wrap around the given Python function.
- Changes in several other files to distinguish between a Python class and a Python instance, from the output of the modified  `load_function_class_from_file`.
# Integration Test
See the [new integration test](https://github.com/Prakhar314/evadb/blob/staging/test/integration_tests/short/test_simple_udf.py) for an example usecase.
We load UDFs from a file with the following content:
```python
def mod5(id:int)->int:
    return id%5
def isEven(id:int)->bool:
    return id%2==0
```
There is no change in the EvaQL interface. This means that the following queries work:
```sql
CREATE FUNCTION mod5 IMPL '<file_location>';
CREATE FUNCTION isEven IMPL '<file_location>';
SELECT mod5(Id) from ....
```
# Todo
- Creating a `UserDefinedFunction` wrapper is a hack to make the minimum functionality work within the current implementation. We need to explore other options like creating a separate executor for simple functions.
- We assume that the functions take one row of the input at a time.
- This implementation is probably not as expressive as extending the `AbstractFunction` class.