### PR TITLE
Job scheduler run flag

### DIFF
--- a/evadb/configuration/constants.py
+++ b/evadb/configuration/constants.py
@@ -29,6 +29,7 @@ INDEX_DIR = "index"
 CACHE_DIR = "cache"
 DATASET_DATAFRAME_NAME = "dataset"
 DB_DEFAULT_NAME = "evadb.db"
+JOB_SCHEDULER_FLAG = "jobs"
 S3_DOWNLOAD_DIR = "s3_downloads"
 TMP_DIR = "tmp"
 DEFAULT_TRAIN_TIME_LIMIT = 120

--- a/evadb/evadb_config.py
+++ b/evadb/evadb_config.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from evadb.configuration.constants import JOB_SCHEDULER_FLAG
+
 """
 EvaDB configuration dict
 
@@ -39,6 +41,7 @@ BASE_EVADB_CONFIG = {
     "port": 8803,
     "socket_timeout": 60,
     "ray": False,
+    JOB_SCHEDULER_FLAG: False,
     "OPENAI_API_KEY": "",
     "PINECONE_API_KEY": "",
     "PINECONE_ENV": "",

--- a/evadb/interfaces/relational/db.py
+++ b/evadb/interfaces/relational/db.py
@@ -45,6 +45,7 @@ from evadb.parser.utils import (
 from evadb.server.command_handler import execute_statement
 from evadb.utils.generic_utils import find_nearest_word, is_ray_enabled_and_installed
 from evadb.utils.job_scheduler import JobScheduler
+from evadb.utils.bootstrap_jobs_scheduler import start_jobs_process
 from evadb.utils.logging_manager import logger
 
 
@@ -605,6 +606,9 @@ def connect(
     # reader and writer parameters are not relevant in the serverless approach.
     evadb = init_evadb_instance(evadb_dir, custom_db_uri=sql_backend)
     init_builtin_functions(evadb, mode="release")
+    
+    # TODO: Preserve jobs process object if needed
+    jobs_process = start_jobs_process(evadb)
     return EvaDBConnection(evadb, None, None)
 
 

--- a/evadb/utils/bootstrap_jobs_scheduler.py
+++ b/evadb/utils/bootstrap_jobs_scheduler.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+# Copyright 2018-2023 EvaDB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing
+
+from evadb.database import EvaDBDatabase
+from evadb.utils.job_scheduler import JobScheduler
+from evadb.utils.logging_manager import logger
+
+def start_jobs_process(db: EvaDBDatabase) -> multiprocessing.Process:
+    """
+    Initializes the jobs process and returns a multiprocessing.Process object
+    """
+    job_scheduler = JobScheduler(db)
+    _jobs_process = multiprocessing.Process(target=job_scheduler.execute)
+    _jobs_process.daemon = True
+    _jobs_process.start()
+    logger.debug("Job scheduler process started")
+    print("Job scheduler process started")
+    return _jobs_process

--- a/evadb/utils/job_scheduler.py
+++ b/evadb/utils/job_scheduler.py
@@ -21,6 +21,7 @@ from evadb.catalog.models.utils import JobCatalogEntry
 from evadb.database import EvaDBDatabase
 from evadb.server.command_handler import execute_query
 from evadb.utils.logging_manager import logger
+from evadb.configuration.constants import JOB_SCHEDULER_FLAG
 
 
 class JobScheduler:
@@ -63,51 +64,58 @@ class JobScheduler:
     def _scan_and_execute_jobs(self):
         while True:
             try:
-                for next_executable_job in iter(
-                    lambda: self._evadb.catalog().get_next_executable_job(
-                        only_past_jobs=True
-                    ),
-                    None,
-                ):
-                    execution_time = datetime.datetime.now()
-
-                    # insert a job history record to mark start of this execution
-                    self._evadb.catalog().insert_job_history_catalog_entry(
-                        next_executable_job.row_id,
-                        next_executable_job.name,
-                        execution_time,
+                job_scheduler_run_flag = self._evadb.catalog().get_configuration_catalog_value(JOB_SCHEDULER_FLAG, False)
+                print("job_scheduler_run_flag: ", job_scheduler_run_flag)
+                if job_scheduler_run_flag:
+                    print("Executing jobs...")
+                    for next_executable_job in iter(
+                        lambda: self._evadb.catalog().get_next_executable_job(
+                            only_past_jobs=True
+                        ),
                         None,
+                    ):
+                        execution_time = datetime.datetime.now()
+
+                        # insert a job history record to mark start of this execution
+                        self._evadb.catalog().insert_job_history_catalog_entry(
+                            next_executable_job.row_id,
+                            next_executable_job.name,
+                            execution_time,
+                            None,
+                        )
+
+                        # execute the queries of the job
+                        execution_results = [
+                            execute_query(self._evadb, query)
+                            for query in next_executable_job.queries
+                        ]
+                        logger.debug(
+                            f"Exection result for job: {next_executable_job.name} results: {execution_results}"
+                        )
+
+                        # update the next trigger time for this job
+                        self._update_next_schedule_run(next_executable_job)
+
+                        # update the previosly inserted job history record with endtime
+                        self._evadb.catalog().update_job_history_end_time(
+                            next_executable_job.row_id,
+                            execution_time,
+                            datetime.datetime.now(),
+                        )
+
+                    next_executable_job = self._evadb.catalog().get_next_executable_job(
+                        only_past_jobs=False
                     )
 
-                    # execute the queries of the job
-                    execution_results = [
-                        execute_query(self._evadb, query)
-                        for query in next_executable_job.queries
-                    ]
-                    logger.debug(
-                        f"Exection result for job: {next_executable_job.name} results: {execution_results}"
-                    )
-
-                    # update the next trigger time for this job
-                    self._update_next_schedule_run(next_executable_job)
-
-                    # update the previosly inserted job history record with endtime
-                    self._evadb.catalog().update_job_history_end_time(
-                        next_executable_job.row_id,
-                        execution_time,
-                        datetime.datetime.now(),
-                    )
-
-                next_executable_job = self._evadb.catalog().get_next_executable_job(
-                    only_past_jobs=False
-                )
-
-                sleep_time = self._get_sleep_time(next_executable_job)
-                if sleep_time > 0:
-                    logger.debug(
-                        f"Job scheduler process sleeping for {sleep_time} seconds"
-                    )
-                    time.sleep(sleep_time)
+                    sleep_time = self._get_sleep_time(next_executable_job)
+                    if sleep_time > 0:
+                        logger.debug(
+                            f"Job scheduler process sleeping for {sleep_time} seconds"
+                        )
+                        time.sleep(sleep_time)
+                else:
+                    print("Job scheduler disabled, sleeping for ", str(self.poll_interval_seconds), " seconds")
+                    time.sleep(self.poll_interval_seconds)
             except Exception as e:
                 logger.error(f"Got an exception in job scheduler: {str(e)}")
                 time.sleep(self.poll_interval_seconds * 0.2)


### PR DESCRIPTION
Configured job scheduler to run based on a configuration.

Job scheduler is initialized during:
1) EvaDB Server mode - During server startup
2) Python package mode - During init of first connection object

The job scheduler process polls the `"jobs"` DB configuration to determine whether to execute background jobs.

This way, the job scheduler can be enabled and disabled via SQL commands using the `SET` statement.


## Usage

### Enable scheduler
`SET jobs = "True"`

### Disable scheduler
`SET jobs = "False"`

The `jobs` configuration is set to "False" by default so there is no change in existing behaviour of the scheduler.