### PR TITLE
Fix #170 Add concurrent query support

### DIFF
--- a/evadb/interfaces/relational/db.py
+++ b/evadb/interfaces/relational/db.py
@@ -112,11 +112,6 @@ class EvaDBCursor(object):
         """
         Send query to the EvaDB server.
         """
-        if self._pending_query:
-            raise SystemError(
-                "EvaDB does not support concurrent queries. \
-                    Call fetch_all() to complete the pending query"
-            )
         query = self._multiline_query_transformation(query)
         self._connection._writer.write((query + "\n").encode())
         await self._connection._writer.drain()

--- a/evadb/server/command_handler.py
+++ b/evadb/server/command_handler.py
@@ -144,3 +144,9 @@ async def handle_request(evadb: EvaDBDatabase, client_writer, request_message):
     client_writer.write(response_data)
 
     return response
+
+async def handle_requests(evadb_server):
+    while True:
+        # Remove request from the queue. If there are no requests, this call blocks.
+        evadb, client_writer, message  = await evadb_server._request_queue.get()
+        await handle_request(evadb, client_writer, message)

--- a/evadb/server/interpreter.py
+++ b/evadb/server/interpreter.py
@@ -70,8 +70,8 @@ async def read_from_client_and_send_to_server(
     cursor = connection.cursor()
 
     # Tasks to run concurrently to remove requests/responses that the server sends/recieves.
-    client_request  = asyncio.create_task(handle_client_requests(cursor, client_request_queue))
-    server_response = asyncio.create_task(handle_server_response(cursor))
+    asyncio.create_task(handle_client_requests(cursor, client_request_queue))
+    asyncio.create_task(handle_server_response(cursor))
 
     while True:
         sys.stdout.write(prompt)


### PR DESCRIPTION
Currently in EvaDB, a client can send a request. Until the request has been fulfilled, the client will be blocked from sending more requests.

This change to EvaDB allows clients to send multiple requests at a time. The server will now handle requests in a FIFO order and it will issue responses following that ordering as well. Once a response has completed, it will be sent to the client asynchronously.
