### PR TITLE
Added SHOW JOBS statement to list all jobs

### DIFF
--- a/evadb/catalog/catalog_manager.py
+++ b/evadb/catalog/catalog_manager.py
@@ -309,6 +309,9 @@ class CatalogManager(object):
         self._job_catalog_service.update_next_scheduled_run(
             job_name, next_scheduled_run, active
         )
+    
+    def get_all_job_catalog_entry_names(self):
+        return self._job_catalog_service.get_all_job_names()
 
     "Job history catalog services"
 

--- a/evadb/catalog/services/job_catalog_service.py
+++ b/evadb/catalog/services/job_catalog_service.py
@@ -161,3 +161,16 @@ class JobCatalogService(BaseService):
             job._next_scheduled_run = next_scheduled_run
             job._active = active
             self.session.commit()
+            
+    def get_all_job_names(self) -> list:
+        """Get the list of names of all jobs
+        Arguments:
+            None
+        Returns:
+            Returns the list of names of all jobs
+        """
+        entries = self.session.execute(
+            select(self.model._name)
+        ).scalars().all()
+        return entries
+        

--- a/evadb/executor/create_job_executor.py
+++ b/evadb/executor/create_job_executor.py
@@ -109,7 +109,7 @@ class CreateJobExecutor(AbstractExecutor):
         start_time = (
             self._parse_datetime_str(self.node.start_time)
             if self.node.start_time is not None
-            else datetime.datetime.now()
+            else datetime.now()
         )
         end_time = (
             self._parse_datetime_str(self.node.end_time)

--- a/evadb/executor/show_info_executor.py
+++ b/evadb/executor/show_info_executor.py
@@ -34,6 +34,7 @@ class ShowInfoExecutor(AbstractExecutor):
             or ShowType.TABLES
             or ShowType.DATABASES
             or ShowType.CONFIGS
+            or ShowType.JOBS
         ), f"Show command does not support type {self.node.show_type}"
 
         if self.node.show_type is ShowType.FUNCTIONS:
@@ -68,5 +69,11 @@ class ShowInfoExecutor(AbstractExecutor):
                     raise Exception(
                         "No configuration found with key {}".format(self.node.show_val)
                     )
+                    
+        elif self.node.show_type is ShowType.JOBS:
+            job_names = self.catalog().get_all_job_catalog_entry_names()
+            for name in job_names:
+                show_entries.append(name)
+            show_entries = {"Job Names": show_entries}
 
         yield Batch(pd.DataFrame(show_entries))

--- a/evadb/parser/evadb.lark
+++ b/evadb/parser/evadb.lark
@@ -197,7 +197,7 @@ describe_statement: DESCRIBE table_name
     
 help_statement: HELP STRING_LITERAL
     
-show_statement: SHOW (FUNCTIONS | TABLES | uid | DATABASES)
+show_statement: SHOW (FUNCTIONS | TABLES | uid | DATABASES | JOBS)
 
 explain_statement: EXPLAIN explainable_statement
 
@@ -387,6 +387,7 @@ INDEX:                               "INDEX"i
 INSERT:                              "INSERT"i
 IS:                                  "IS"i
 JOB:                                 "JOB"i
+JOBS:                                "JOBS"i
 JOIN:                                "JOIN"i
 KEY:                                 "KEY"i
 LATERAL:                             "LATERAL"i

--- a/evadb/parser/lark_visitor/_show_statements.py
+++ b/evadb/parser/lark_visitor/_show_statements.py
@@ -29,5 +29,7 @@ class Show:
             return ShowStatement(show_type=ShowType.TABLES)
         elif isinstance(token, str) and str.upper(token) == "DATABASES":
             return ShowStatement(show_type=ShowType.DATABASES)
+        elif isinstance(token, str) and str.upper(token) == "JOBS":
+            return ShowStatement(show_type=ShowType.JOBS)
         elif token is not None:
             return ShowStatement(show_type=ShowType.CONFIGS, show_val=self.visit(token))

--- a/evadb/parser/show_statement.py
+++ b/evadb/parser/show_statement.py
@@ -44,6 +44,8 @@ class ShowStatement(AbstractStatement):
             show_str = self.show_val
         elif self.show_type == ShowType.DATABASES:
             show_str = "DATABASES"
+        elif self.show_type == ShowType.JOBS:
+            show_str = "JOBS"
         return f"SHOW {show_str}"
 
     def __eq__(self, other: object) -> bool:

--- a/evadb/parser/types.py
+++ b/evadb/parser/types.py
@@ -73,6 +73,7 @@ class ShowType(EvaDBEnum):
     TABLES  # noqa: F821
     CONFIGS  # noqa: F821
     DATABASES  # noqa: F821
+    JOBS # noqa: F821
 
 
 class FunctionType(EvaDBEnum):


### PR DESCRIPTION

## SHOW JOBS

Added support to list all jobs using the `SHOW` statement.

### Usage

`SHOW jobs`

## Minor Bug fix
Fixed minor bug in CREATE JOB

**Bug description**: Error thrown when `START` parameter is empty in `CREATE JOB` statement due to minor mistake in use of datetime.now()