### PR TITLE
Fixes broken unit test - test_evadb_client

### DIFF
--- a/test/unit_tests/test_eva_cmd_client.py
+++ b/test/unit_tests/test_eva_cmd_client.py
@@ -23,7 +23,7 @@ from evadb.evadb_config import BASE_EVADB_CONFIG
 
 
 # @pytest.mark.skip
-class CMDClientTest(unittest.TestCase):
+class CMDClientTest(unittest.IsolatedAsyncioTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
## Problem
Unit test suite is broken. ([Last run](https://app.circleci.com/pipelines/github/georgia-tech-db/evadb/6360/workflows/4b306256-29cf-421c-b173-02877f63b431/jobs/45957))
Broken test - `CMDClientTest::test_evadb_client`
Error: `RuntimeError: There is no current event loop in thread 'MainThread'`
The test runs fine when run individually but fails when whole suite is run together because other asyncio tests update the asyncio loop settings and policies.

## Solution
Update test class to extend from `IsolatedAsyncioTestCase` which provides better isolation when running multiple asyncio test units.